### PR TITLE
Shorten the math position paper title

### DIFF
--- a/information-sharing/position-paper-plain-text-math/index.html
+++ b/information-sharing/position-paper-plain-text-math/index.html
@@ -2,9 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
 	<head>
 		<meta charset="utf-8" />
-		<title>Position
-Statement: When to use math Represented as plain Text or Images of Math
-Instead of MathML</title>
+		<title>Position Statement: When to use plain text or images instead of MathML</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script class="remove">
 			//<![CDATA[


### PR DESCRIPTION
Changes the title from:

> Position Statement: When to use math Represented as plain Text or Images of Math Instead of MathML

to: 

> Position Statement: When to use plain text or images instead of MathML