### PR TITLE
Experimental language change tests

### DIFF
--- a/language_change/Language_change_locales.xhtml
+++ b/language_change/Language_change_locales.xhtml
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-US" lang="en-US">
 
 <head>
-  <title>Language change main lang code</title>
+  <title>Language change locals lang code</title>
   <meta charset="utf-8" />
   <link rel="stylesheet" type="text/css" href="../css/base.css" />
 </head>

--- a/language_change/Language_change_locales.xhtml
+++ b/language_change/Language_change_locales.xhtml
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-US" lang="en-US">
+
+<head>
+  <title>Language change main lang code</title>
+  <meta charset="utf-8" />
+  <link rel="stylesheet" type="text/css" href="../css/base.css" />
+</head>
+
+<body>
+  <section id="reading-1512" class="test">
+
+    <h1><span class="test-id">reading-1511</span> <span class="test-title">TTS Change Languages Automatically (main language code</span></h2>
+
+    <p class="desc">Screen readers and other Assistive Technology that use TTS should be able to detect language changes marked in XHTML content. A screen reader should be able to be configured to automatically change the TTS speaking language when it encounters a language change in the XHTML. In some cases available voices are dependant of the operating system. to perform this test, tester must be sure that the following languages are installed on his computer:
+      <ul>
+        <li>English, US</li>
+        <li>French, Canada</li>
+      </ul>
+    </p>
+
+<p> Configure your screen reader or other Assistive Technology to automatically change the TTS language. Read the phrases below line by line and continuously. The test passes if the TTS language changes as it encounters the language change.</p>
+
+    <p class="eval">Indicate Pass or Fail.</p>
+
+<h3>Language Change Test</h3>
+
+<p>In US English, "Good morning my darling."; In french Canadian, <span xml:lang="fr-ca" lang="fr-ca">"Bonjour ma chérie."</span></p>
+
+<p>End of language change testing.</p>
+
+</section>
+</body>
+language_change/Language_change_locales.xhtml language_change/Language_change_main.xhtml
+
+</html>

--- a/language_change/Language_change_main.xhtml
+++ b/language_change/Language_change_main.xhtml
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+
+<head>
+  <title>Language change main lang code</title>
+  <meta charset="utf-8" />
+  <link rel="stylesheet" type="text/css" href="../css/base.css" />
+</head>
+
+<body>
+  <section id="reading-1510" class="test">
+
+    <h1><span class="test-id">reading-1511</span> <span class="test-title">TTS Change Languages Automatically (main language code</span></h2>
+
+    <p class="desc">Screen readers and other Assistive Technology that use TTS should be able to detect language changes marked in XHTML content. A screen reader should be able to be configured to automatically change the TTS speaking language when it encounters a language change in the XHTML. In some cases available voices are dependant of the operating system. to perform this test, tester must be sure that the following languages are installed on his computer:
+      <ul>
+        <li>English</li>
+        <li>French</li>
+      </ul>
+    </p>
+
+<p> Configure your screen reader or other Assistive Technology to automatically change the TTS language. Read the phrases below line by line and continuously. The test passes if the TTS language changes as it encounters the language change.</p>
+
+    <p class="eval">Indicate Pass or Fail.</p>
+
+<h3>Language Change Test</h3>
+
+<p>In English, "Good morning my darling."; In french, <span xml:lang="fr" lang="fr">"Bonjour ma chérie."</span></p>
+
+<p>End of language change testing.</p>
+
+</section>
+</body>
+
+</html>


### PR DESCRIPTION
As discussed during group call, January 16, 2024.
This adds, at the root, one folders named _language_change_ inside of which two files: 

- one for language switching with ISO 639-1 two letters code (_en_ and _fr_)
- one for local language support with ISO 639-1 + two letter country codes (_en-US_ and _fr-CA_)