### PR TITLE
Experimental language change tests

### DIFF
--- a/language_change/Language_change_locales.xhtml
+++ b/language_change/Language_change_locales.xhtml
@@ -10,20 +10,20 @@
 <body>
   <section id="reading-1512" class="test">
 
-    <h1><span class="test-id">reading-1511</span> <span class="test-title">TTS Change Languages Automatically (main language code</span></h2>
+    <h1><span class="test-id">reading-1511</span> <span class="test-title">TTS Change Languages Automatically (main language code)</span></h1>
 
-    <p class="desc">Screen readers and other Assistive Technology that use TTS should be able to detect language changes marked in XHTML content. A screen reader should be able to be configured to automatically change the TTS speaking language when it encounters a language change in the XHTML. In some cases available voices are dependant of the operating system. to perform this test, tester must be sure that the following languages are installed on his computer:
+    <p class="desc">Screen readers and other Assistive Technology that use TTS should be able to detect language changes marked in XHTML content. A screen reader should be able to be configured to automatically change the TTS speaking language when it encounters a language change in the XHTML. In some cases available voices are dependant of the operating system. to perform this test, tester must be sure that the following languages are installed on his computer:</p>
       <ul>
         <li>English, US</li>
         <li>French, Canada</li>
       </ul>
-    </p>
+    
 
 <p> Configure your screen reader or other Assistive Technology to automatically change the TTS language. Read the phrases below line by line and continuously. The test passes if the TTS language changes as it encounters the language change.</p>
 
     <p class="eval">Indicate Pass or Fail.</p>
 
-<h3>Language Change Test</h3>
+<h2>Language Change Test</h2>
 
 <p>In US English, "this is a very good book"; In french Canadian, <span xml:lang="fr-ca" lang="fr-ca">"c'est un très bon livre"</span>.</p>
 

--- a/language_change/Language_change_locales.xhtml
+++ b/language_change/Language_change_locales.xhtml
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-US" lang="en-US">
+
+<head>
+  <title>Language change locals lang code</title>
+  <meta charset="utf-8" />
+  <link rel="stylesheet" type="text/css" href="../css/base.css" />
+</head>
+
+<body>
+  <section id="reading-1512" class="test">
+
+    <h1><span class="test-id">reading-1511</span> <span class="test-title">TTS Change Languages Automatically (main language code</span></h2>
+
+    <p class="desc">Screen readers and other Assistive Technology that use TTS should be able to detect language changes marked in XHTML content. A screen reader should be able to be configured to automatically change the TTS speaking language when it encounters a language change in the XHTML. In some cases available voices are dependant of the operating system. to perform this test, tester must be sure that the following languages are installed on his computer:
+      <ul>
+        <li>English, US</li>
+        <li>French, Canada</li>
+      </ul>
+    </p>
+
+<p> Configure your screen reader or other Assistive Technology to automatically change the TTS language. Read the phrases below line by line and continuously. The test passes if the TTS language changes as it encounters the language change.</p>
+
+    <p class="eval">Indicate Pass or Fail.</p>
+
+<h3>Language Change Test</h3>
+
+<p>In US English, "this is a very good book"; In french Canadian, <span xml:lang="fr-ca" lang="fr-ca">"c'est un très bon livre"</span>.</p>
+
+<p>End of language change testing.</p>
+
+</section>
+</body>
+
+</html>

--- a/language_change/Language_change_main.xhtml
+++ b/language_change/Language_change_main.xhtml
@@ -10,20 +10,20 @@
 <body>
   <section id="reading-1510" class="test">
 
-    <h1><span class="test-id">reading-1511</span> <span class="test-title">TTS Change Languages Automatically (main language code</span></h2>
+    <h1><span class="test-id">reading-1511</span> <span class="test-title">TTS Change Languages Automatically (main language code</span></h1>
 
-    <p class="desc">Screen readers and other Assistive Technology that use TTS should be able to detect language changes marked in XHTML content. A screen reader should be able to be configured to automatically change the TTS speaking language when it encounters a language change in the XHTML. In some cases available voices are dependant of the operating system. to perform this test, tester must be sure that the following languages are installed on his computer:
+    <p class="desc">Screen readers and other Assistive Technology that use TTS should be able to detect language changes marked in XHTML content. A screen reader should be able to be configured to automatically change the TTS speaking language when it encounters a language change in the XHTML. In some cases available voices are dependant of the operating system. to perform this test, tester must be sure that the following languages are installed on his computer:</p>
       <ul>
         <li>English</li>
         <li>French</li>
       </ul>
-    </p>
+    
 
 <p> Configure your screen reader or other Assistive Technology to automatically change the TTS language. Read the phrases below line by line and continuously. The test passes if the TTS language changes as it encounters the language change.</p>
 
     <p class="eval">Indicate Pass or Fail.</p>
 
-<h3>Language Change Test</h3>
+<h2>Language Change Test</h2>
 
 <p>In English, "this is a very good book"; In french, <span xml:lang="fr" lang="fr">"c'est un très bon livre"</span>.</p>
 

--- a/language_change/Language_change_main.xhtml
+++ b/language_change/Language_change_main.xhtml
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+
+<head>
+  <title>Language change main lang code</title>
+  <meta charset="utf-8" />
+  <link rel="stylesheet" type="text/css" href="../css/base.css" />
+</head>
+
+<body>
+  <section id="reading-1510" class="test">
+
+    <h1><span class="test-id">reading-1511</span> <span class="test-title">TTS Change Languages Automatically (main language code</span></h2>
+
+    <p class="desc">Screen readers and other Assistive Technology that use TTS should be able to detect language changes marked in XHTML content. A screen reader should be able to be configured to automatically change the TTS speaking language when it encounters a language change in the XHTML. In some cases available voices are dependant of the operating system. to perform this test, tester must be sure that the following languages are installed on his computer:
+      <ul>
+        <li>English</li>
+        <li>French</li>
+      </ul>
+    </p>
+
+<p> Configure your screen reader or other Assistive Technology to automatically change the TTS language. Read the phrases below line by line and continuously. The test passes if the TTS language changes as it encounters the language change.</p>
+
+    <p class="eval">Indicate Pass or Fail.</p>
+
+<h3>Language Change Test</h3>
+
+<p>In English, "this is a very good book"; In french, <span xml:lang="fr" lang="fr">"c'est un très bon livre"</span>.</p>
+
+<p>End of language change testing.</p>
+
+</section>
+</body>
+
+</html>

--- a/language_change/Language_change_threeletters.xhtml
+++ b/language_change/Language_change_threeletters.xhtml
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="eng" lang="eng">
+
+<head>
+  <title>Language change locals lang code three letters</title>
+  <meta charset="utf-8" />
+  <link rel="stylesheet" type="text/css" href="../css/base.css" />
+</head>
+
+<body>
+  <section id="reading-1512" class="test">
+
+    <h1><span class="test-id">reading-1513</span> <span class="test-title">TTS Change Languages Automatically (main language code, three letters)</span></h2>
+
+    <p class="desc">Screen readers and other Assistive Technology that use TTS should be able to detect language changes marked in XHTML content. A screen reader should be able to be configured to automatically change the TTS speaking language when it encounters a language change in the XHTML. 
+     This test variant is set to three letters langage code (eng and fra). 
+    In some cases available voices are dependant of the operating system. to perform this test, tester must be sure that the following languages are installed on his computer:
+      <ul>
+        <li>English</li>
+        <li>French</li>
+      </ul>
+    </p>
+
+<p> Configure your screen reader or other Assistive Technology to automatically change the TTS language. Read the phrases below line by line and continuously. The test passes if the TTS language changes as it encounters the language change.</p>
+
+    <p class="eval">Indicate Pass or Fail.</p>
+
+<h3>Language Change Test</h3>
+
+<p>In English, "this is a very good book"; In french, <span xml:lang="fra" lang="fra">"c'est un très bon livre"</span>.</p>
+
+<p>End of language change testing.</p>
+
+</section>
+</body>
+
+</html>

--- a/language_change/Language_change_threeletters.xhtml
+++ b/language_change/Language_change_threeletters.xhtml
@@ -10,22 +10,22 @@
 <body>
   <section id="reading-1512" class="test">
 
-    <h1><span class="test-id">reading-1513</span> <span class="test-title">TTS Change Languages Automatically (main language code, three letters)</span></h2>
+    <h1><span class="test-id">reading-1513</span> <span class="test-title">TTS Change Languages Automatically (main language code, three letters)</span></h1>
 
     <p class="desc">Screen readers and other Assistive Technology that use TTS should be able to detect language changes marked in XHTML content. A screen reader should be able to be configured to automatically change the TTS speaking language when it encounters a language change in the XHTML. 
      This test variant is set to three letters langage code (eng and fra). 
-    In some cases available voices are dependant of the operating system. to perform this test, tester must be sure that the following languages are installed on his computer:
+    In some cases available voices are dependant of the operating system. to perform this test, tester must be sure that the following languages are installed on his computer:</p>
       <ul>
         <li>English</li>
         <li>French</li>
       </ul>
-    </p>
+    
 
 <p> Configure your screen reader or other Assistive Technology to automatically change the TTS language. Read the phrases below line by line and continuously. The test passes if the TTS language changes as it encounters the language change.</p>
 
     <p class="eval">Indicate Pass or Fail.</p>
 
-<h3>Language Change Test</h3>
+<h2>Language Change Test</h2>
 
 <p>In English, "this is a very good book"; In french, <span xml:lang="fra" lang="fra">"c'est un très bon livre"</span>.</p>
 


### PR DESCRIPTION
As discussed during group call, January 16, 2024.
This adds, at the root, one folders named _language_change_ with three files files: 
* test for language change iso 639-1 without country code (i.e. two letters only)
* test for language change iso 639-1 with country code (i.e. four letters)
* test for language change iso 639-2 without country code (i.e. three letters)