### PR TITLE
New two letters shifts (EN to FR and variants + FR to EN and variants)

### DIFF
--- a/language_change/Language_change_main_en_to_fr.xhtml
+++ b/language_change/Language_change_main_en_to_fr.xhtml
@@ -2,15 +2,15 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 
 <head>
-  <title>Language change main lang code</title>
+  <title>Language change main lang code EN to FR</title>
   <meta charset="utf-8" />
   <link rel="stylesheet" type="text/css" href="../css/base.css" />
 </head>
 
 <body>
-  <section id="reading-1510" class="test">
+  <section id="reading-1511" class="test">
 
-    <h1><span class="test-id">reading-1511</span> <span class="test-title">TTS Change Languages Automatically (main language code</span></h1>
+    <h1><span class="test-id">reading-1511</span> <span class="test-title">TTS Change Languages Automatically (main language code)</span></h1>
 
     <p class="desc">Screen readers and other Assistive Technology that use TTS should be able to detect language changes marked in XHTML content. A screen reader should be able to be configured to automatically change the TTS speaking language when it encounters a language change in the XHTML. In some cases available voices are dependant of the operating system. to perform this test, tester must be sure that the following languages are installed on his computer:</p>
       <ul>
@@ -23,9 +23,13 @@
 
     <p class="eval">Indicate Pass or Fail.</p>
 
-<h2>Language Change Test</h2>
+<h2>Language Change Test two letters (main)</h2>
 
 <p>In English, "this is a very good book"; In french, <span xml:lang="fr" lang="fr">"c'est un très bon livre"</span>.</p>
+  
+<h2>Language Change Test two + two letters (main and variant)</h2>
+
+<p><span xml:lang="en-US" lang="en-US">"In American English, "this is a very good book"</span>. ; In french Canadian, <span xml:lang="fr-ca" lang="fr-ca">"c'est un très bon livre"</span>.</p>
 
 <p>End of language change testing.</p>
 

--- a/language_change/Language_change_main_fr_to_en.xhtml
+++ b/language_change/Language_change_main_fr_to_en.xhtml
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="fr" lang="fr">
+
+<head>
+  <title>Changement de langue en français FR vers EN</title>
+  <meta charset="utf-8" />
+  <link rel="stylesheet" type="text/css" href="../css/base.css" />
+</head>
+
+<body>
+  <section id="reading-1512" class="test">
+
+    <h1><span class="test-id">reading-1512</span> <span class="test-title">TTS Changement automatique de langue (code de la langue principale)</span></h1>
+
+    <p class="desc">Les lecteurs d'écran et autres technologies d'assistance qui utilisent le TTS doivent être en mesure de détecter les changements de langue marqués dans le contenu XHTML. Un lecteur d'écran doit pouvoir être configuré pour changer automatiquement la langue d'énonciation du TTS lorsqu'il rencontre un changement de langue dans le XHTML. Dans certains cas, les voix disponibles dépendent du système d'exploitation. Pour effectuer ce test, le testeur doit s'assurer que les langues suivantes sont installées sur son ordinateur :</p>
+      <ul>
+        <li>Anglais</li>
+        <li>Français</li>
+      </ul>
+    
+
+<p>Configurez votre lecteur d'écran ou toute autre technologie d'assistance pour changer automatiquement la langue TTS. Lisez les phrases ci-dessous ligne par ligne et en continu. Le test est réussi si la langue du TTS change au fur et à mesure qu'il rencontre le changement de langue.</p>
+
+    <p class="eval">Indicate Pass or Fail.</p>
+
+<h2>Language Change Test</h2>
+
+<p>En français "c'est un très bon livre ; <span xml:lang="en" lang="en">"In English, "this is a very good book"</span>.<span xml:lang="en-US" lang="en-US">"In American English now, "this is a very good book"</span></p>
+
+<h2>Test de changement de langue deux + deux lettres (principale et variante)</h2>
+
+<p><span xml:lang="en-US" lang="en-US">"In American English, "this is a very good book"</span>. ; In french Canadian, <span xml:lang="fr-ca" lang="fr-ca">"c'est un très bon livre"</span>.</p>
+
+<p>Fin des tests de changement de langue.</p>
+
+</section>
+</body>
+
+</html>

--- a/language_change/Language_change_threeletters.xhtml
+++ b/language_change/Language_change_threeletters.xhtml
@@ -8,9 +8,9 @@
 </head>
 
 <body>
-  <section id="reading-1512" class="test">
+  <section id="reading-1514" class="test">
 
-    <h1><span class="test-id">reading-1513</span> <span class="test-title">TTS Change Languages Automatically (main language code, three letters)</span></h1>
+    <h1><span class="test-id">reading-1514</span> <span class="test-title">TTS Change Languages Automatically (main language code, three letters)</span></h1>
 
     <p class="desc">Screen readers and other Assistive Technology that use TTS should be able to detect language changes marked in XHTML content. A screen reader should be able to be configured to automatically change the TTS speaking language when it encounters a language change in the XHTML. 
      This test variant is set to three letters langage code (eng and fra). 

--- a/language_change/Language_change_threeletters.xhtml
+++ b/language_change/Language_change_threeletters.xhtml
@@ -8,9 +8,9 @@
 </head>
 
 <body>
-  <section id="reading-1514" class="test">
+  <section id="reading-1512" class="test">
 
-    <h1><span class="test-id">reading-1514</span> <span class="test-title">TTS Change Languages Automatically (main language code, three letters)</span></h1>
+    <h1><span class="test-id">reading-1513</span> <span class="test-title">TTS Change Languages Automatically (main language code, three letters)</span></h1>
 
     <p class="desc">Screen readers and other Assistive Technology that use TTS should be able to detect language changes marked in XHTML content. A screen reader should be able to be configured to automatically change the TTS speaking language when it encounters a language change in the XHTML. 
      This test variant is set to three letters langage code (eng and fra). 


### PR DESCRIPTION
As discussed in the February 13th call, the Main lang code is now available in FR to EN. For better identification I had to change file names so looks like all new files.
* reading-1511 has main language EN and shifts to FR, en-US and fr-CA.
* reading-1512 has main language FR and shifts to EN, en-US and fr-CA. To be consistent, this one has test definition in French.