### PR TITLE
From june4 meeting suggestions

### DIFF
--- a/dpub-aria-testing/content/DPUB-ARIA-tests.xhtml
+++ b/dpub-aria-testing/content/DPUB-ARIA-tests.xhtml
@@ -23,7 +23,7 @@
 		<dl>
 			<dt>critical</dt><dd>should  always be presented, unless "none" is selected.</dd>
 			<dt>high</dt><dd>should be presented when "some" "most," or "all"is selected.</dd>
-			<dt>medium</dt><dd>should be presented when "some" or "all"  is selected.</dd>
+			<dt>medium</dt><dd>should be presented when "most" or "all"  is selected.</dd>
 			<dt>low</dt><dd>should be presented     when "all" is selected.</dd>
 		</dl>
 

--- a/dpub-aria-testing/content/DPUB-ARIA-tests.xhtml
+++ b/dpub-aria-testing/content/DPUB-ARIA-tests.xhtml
@@ -27,25 +27,26 @@
 			<dt>low</dt><dd>should be presented     when "all" is selected.</dd>
 		</dl>
 
+<p>Note: a verbosity selection of"some" includes critical and high importance. A verbosity selection of "most includes critical, high, and medium.</p> 
 		<h2 id="doc-abstract">doc-abstract Test</h2>
 		<div role="doc-abstract">This text in the div element has the role of abstract.</div>
-		<p>This is a high priority. Many times the word "abstract" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to high.</p>
+		<p>This is a high priority. Many times the word "abstract" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to some, most, or all.</p>
 		<p>Suggested output: "abstract"</p>
-		<h2 id="doc-acknowx`ledgments">doc-acknowledgments Test</h2>
+		<h2 id="doc-acknowledgments">doc-acknowledgments Test</h2>
 		<div role="doc-acknowledgments">This text in the <code>div</code> element has the role of acknowledgments.</div>
-		<p>This is a low priority. Many times the word "Acknowledgements" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to low.</p>
-		<p>Suggested output: "acknowledgements"</p>
+		<p>This is a low priority. Many times the word "Acknowledgements" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to all.</p>
+		<p>Suggested output: "acknowledgments"</p>
 		<h2 id="doc-afterword">doc-afterword Test</h2>
 		<div role="doc-afterword">This text in the div element has the role of afterword.</div>
-		<p>This is a medium priority. Many times the word "Afterword" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to medium.</p>
+		<p>This is a medium priority. Many times the word "Afterword" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to Most or all.</p>
 		<p>Suggested output: "afterword"</p>
 		<h2 id="doc-appendix">doc-appendix Test</h2>
 		<div role="doc-appendix">This text in the <code>div</code> element has the role of appendix.</div>
-		<p>This is a medium priority. Many times the word "Appendix" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to medium.</p>
+		<p>This is a medium priority. Many times the word "Appendix" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to most or all.</p>
 		<p>Suggested output: "appendix"</p>
 		<h2 id="doc-backlink">doc-backlink Test</h2>
 		<a role="doc-backlink" href="#">a backlink</a>
-		<p>This is a critical priority. The vocalization of the information that it is a back link should always be vocalized.</p>
+		<p>This is a critical priority. The vocalization of the information that it is a back link should always be vocalized, unless none is selected.</p>
 		<p>Suggested output: "back link"</p>
 		<p>This is an "actionable item" meaning the user would follow the back link to return to the identified position in the publication.</p>
 		<h2 id="doc-bibliography">doc-bibliography Test</h2>
@@ -58,40 +59,40 @@
 			</ul>
 		</section>
 		<div role="doc-bibliography">This text in the <code>div</code> element has bibliography role. Test added to check if it acts differently from role on <code>section</code> tag.</div>
-		<p>This is a medium priority. Many times the word "bibliography" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to medium.</p>
+		<p>This is a medium priority. Many times the word "bibliography" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to Most or all.</p>
 		<p>Suggested output: "bibliography"</p>
 		<h2 id="doc-biblioref">doc-biblioref Test</h2>
 		<a role="doc-biblioref" href="#">a role of biblioref.</a>
-		<p>This is a critical priority. The vocalization of the information that it is a Bibliographic reference link should always be vocalized.</p>
+		<p>This is a critical priority. The vocalization of the information that it is a Bibliographic reference link should always be vocalized, unless none is selected.</p>
 		<p>Suggested output: "bibliographic reference"</p>
 		<p>This is an "actionable item" meaning the user would follow the link to go to the reference identified.</p>
 		<h2 id="doc-chapter">doc-chapter Test</h2>
 		<div role="doc-chapter">This text has the  role of chapter.</div>
-		<p>This is a high priority. Many times the word "chapter" will not appear in the heading. It should be vocalized when the verbosity is set to high.</p>
+		<p>This is a high priority. Many times the word "chapter" will not appear in the heading. It should be vocalized when the verbosity is set to some, most, or all.</p>
 		<p>Suggested output: "chapter"</p>
 		<h2 id="doc-colophon">doc-colophon Test</h2>
 		<div role="doc-colophon">This text has the role of colophon.</div>
-		<p>This is a low priority. Many times the word "colophon" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to low.</p>
+		<p>This is a low priority. Many times the word "colophon" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to all.</p>
 		<p>Suggested output: "colophon"</p>
 		<h2 id="doc-conclusion">doc-conclusion Test</h2>
 		<div role="doc-conclusion">This text has the  role of conclusion.</div>
-		<p>This is a medium priority. Many times the word "conclusion" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to medium.</p>
+		<p>This is a medium priority. Many times the word "conclusion" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to  most or all.</p>
 		<p>Suggested output: "conclusion"</p>
 		<h2 id="doc-cover">doc-cover Test</h2>
 		<img role="doc-cover" src="image_001.jpg" alt="A beautiful cover with role of cover."/>
-		<p>This is a medium priority. Many times the word "Cover" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to medium.</p>
+		<p>This is a medium priority. Many times the word "Cover" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to most or all.</p>
 		<p>Suggested output, "cover"</p>
 		<h2 id="doc-credit">doc-credit Test</h2>
 		<div role="doc-credit">This text has the role of credit.</div>
-		<p>This is a low priority. Many times the word "credit" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to low.</p>
+		<p>This is a low priority. Many times the word "credit" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to all.</p>
 		<p>Suggested output: "credit"</p>
 		<h2 id="doc-credits">doc-credits Test</h2>
 		<div role="doc-credits">This text has the role of credits.</div>
-		<p>This is a low priority. Many times the word "credits" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to low.</p>
+		<p>This is a low priority. Many times the word "credits" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to all.</p>
 		<p>Suggested output: "credits"</p>
 		<h2 id="doc-dedication">doc-dedication Test</h2>
 		<div role="doc-dedication">This text has the role of dedication.</div>
-		<p>This is a medium priority. Many times the word "dedication" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to medium.</p>
+		<p>This is a medium priority. Many times the word "dedication" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to most or all.</p>
 		<p>Suggested output: "dedication"</p>
 		<h2 id="doc-endnotes">doc-endnotes Tests</h2>
 		<section role="doc-endnotes">
@@ -101,106 +102,106 @@
 				<li>list item inside endnotes</li>
 				<li>second list item inside endnotes</li>
 			</ul>
-			<p>This is a critical priority. Many times the word "end notes" would be included in the heading associated with this item. It should be vocalized all of the time. </p>
+			<p>This is a critical priority. Many times the word "end notes" would be included in the heading associated with this item. It should be vocalized all of the time, unless none is selected. </p>
 			<p>Suggested output: "endnotes"</p>
 		</section>
 		<div role="doc-endnotes">This text in the <code>div</code> element has the endnotes role. Test added to check if it acts differently from role on <code>section</code> tag.</div>
 		<h2 id="doc-epigraph">doc-epigraph Test</h2>
 		<div role="doc-epigraph">This text has the role of epigraph.</div>
-		<p>This is a low priority. Many times the word "epigraph" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to low.</p>
+		<p>This is a low priority. Many times the word "epigraph" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to all.</p>
 		<p>Suggested output: "epigraph"</p>
 		<h2 id="doc-epilogue">doc-epilogue Test</h2>
 		<div role="doc-epilogue">This test has the role of epilogue.</div>
-		<p>This is a medium priority. Many times the word "epilogue" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to medium.</p>
+		<p>This is a medium priority. Many times the word "epilogue" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to most or all.</p>
 		<p>Suggested output: "epilogue"</p>
 		<h2 id="doc-errata">doc-errata Test</h2>
 		<div role="doc-errata">This text has the role of errata.</div>
-		<p>This is a low priority. Many times the word "errata" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to low.</p>
+		<p>This is a low priority. Many times the word "errata" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to all.</p>
 		<p>Suggested output: "errata"</p>
 		<h2 id="doc-example">doc-example Test</h2>
 		<div role="doc-example">This text has the role of example.</div>
-		<p>This is a medium priority. Many times the word "example" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to medium.</p>
+		<p>This is a medium priority. Many times the word "example" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to most or all.</p>
 		<p>Suggested output: "example"</p>
 		<h2 id="doc-footnote">doc-footnote Test</h2>
 		<div role="doc-footnote">This text has the role of footnote.</div>
-		<p>This is a critical priority. Many times the word "footnote" would be included in the heading associated with this item. It should always be vocalized.</p>
+		<p>This is a critical priority. Many times the word "footnote" would be included in the heading associated with this item. It should always be vocalized, unless none is selected.</p>
 		<p>Suggested output: "footnote"</p>
 		<h2 id="doc-foreword">doc-foreword Test</h2>
 		<div role="doc-foreword">This text has the role of foreword.</div>
-		<p>This is a medium priority. Many times the word "foreword" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to medium.</p>
+		<p>This is a medium priority. Many times the word "foreword" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to most or all.</p>
 		<p>Suggested output: "foreword"</p>
 		<h2 id="doc-glossary">doc-glossary Test</h2>
 		<div role="doc-glossary">
 			This text has the role of glossary.
-			<p>This is a medium priority. Many times the word "glossary" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to medium.</p>
+			<p>This is a medium priority. Many times the word "glossary" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to most or all.</p>
 			<p>Suggested output: "glossary"</p>
 			<span role="term">foo role of term.</span>: <span role="definition">bar role of definition.</span>
 		</div>
 		<h2 id="doc-glossref">doc-glossref Test</h2>
 		<a role="doc-glossref" href="#">a glossary reference</a>
-		<p>This is a critical priority. The vocalization of the information that it is a glossary reference link should always be vocalized.</p>
+		<p>This is a critical priority. The vocalization of the information that it is a glossary reference link should always be vocalized, unless none is selected.</p>
 		<p>Suggested output: "glossary reference"</p>
 		<p>This is an "actionable item" meaning the user would follow the link to go to the reference identified.</p>
 		<h2 id="doc-index">doc-index Test</h2>
 		<div role="doc-index">This text has the role of index.</div>
-		<p>This is a medium priority. Many times the word "index" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to medium.</p>
+		<p>This is a medium priority. Many times the word "index" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to Most or all.</p>
 		<p>Suggested output: "index"</p>
 		<h2 id="doc-introduction">doc-introduction Test</h2>
 		<div role="doc-introduction">This text has the role of introduction.</div>
-		<p>This is a medium priority. Many times the word "introduction" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to medium.</p>
+		<p>This is a medium priority. Many times the word "introduction" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to most or all.</p>
 		<p>Suggested output: "introduction"</p>
 		<h2 id="doc-noteref">doc-noteref Test</h2>
 		<a role="doc-noteref" href="#">a note reference</a>
-		<p>This is a critical priority. The vocalization of the information that it is a note reference link should always be vocalized.</p>
+		<p>This is a critical priority. The vocalization of the information that it is a note reference link should always be vocalized, unless none is selected.</p>
 		<p>Suggested output: "note reference"</p>
 		<p>This is an "actionable item" meaning the user would follow the link to go to the reference identified.</p>
 		<h2 id="doc-notice">doc-notice Test</h2>
 		<div role="doc-notice">This text has the role of notice.</div>
 		<p>This is a high priority. 
-			the word "notice or caution" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to high.
+			the word "notice or caution" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to some, most, or all.
 		</p>
 		<p>Suggested output: "notice"</p>
 		<h2 id="doc-pagebreak">doc-pagebreak Test</h2>
 		<p>In this text there is a pagebreak <span role="doc-pagebreak" aria-label="23" />.</p>
-		<p>This is a critical priority. The vocalization of the information that it is a page break should always be vocalized.</p>
+		<p>This is a critical priority. The vocalization of the information that it is a page break should always be vocalized, unless none is selected.</p>
 		<p>Suggested output: "page break"</p>
 		<p>This is an "actionable item" meaning the user would want to go to the previous or next page break. This is an excellent candidate for single letter navigation and the letter <kbd>p</kbd> is suggested. </p>
 		<h2 id="doc-pagelist">doc-pagelist Test</h2>
 		<div role="doc-pagelist">This text has the role of pagelist.</div>
-		<p>This is a critical priority. The vocalization of the information that it is a list of links to pages should always be vocalized.</p>
+		<p>This is a critical priority. The vocalization of the information that it is a list of links to pages should always be vocalized, unless none is selected.</p>
 		<p>Suggested output: "list of pages"</p>
 		<p>This is an "actionable item" meaning the user would want to be taken to the list of pages or if they were presented with a list of pages, it would be announced.</p>
 		<h2 id="doc-part">doc-part Test</h2>
 		<div role="doc-part">This text has the role of part.</div>
-		<p>This is a high priority. Many times the word "part" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to high.</p>
+		<p>This is a high priority. Many times the word "part" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to most, some, or all .</p>
 		<p>Suggested output: "part"</p>
 		<h2 id="doc-preface">doc-preface Test</h2>
 		<div role="doc-preface">This text has the role of preface.</div>
-		<p>This is a medium priority. Many times the word "preface" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to medium.</p>
+		<p>This is a medium priority. Many times the word "preface" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to most  or all.</p>
 		<p>Suggested output: "preface"</p>
 		<h2 id="doc-prologue">doc-prologue Test</h2>
 		<div role="doc-prologue">This text has the role of prologue.</div>
-		<p>This is a medium priority. Many times the word "prolog" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to medium.</p>
+		<p>This is a medium priority. Many times the word "prolog" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to most or all.</p>
 		<p>Suggested output: "prolog"</p>
 		<h2 id="doc-pullquote">doc-pullquote Test</h2>
 		<div role="doc-pullquote">This text has the role of pullquote.</div>
-		<p>This is a high priority. Many times emphasized portions of  text are in a margin or pulled to the side. The information that emphasized text is being presented should be vocalized when the verbosity is set to high.</p>
+		<p>This is a high priority. Many times emphasized portions of  text are in a margin or pulled to the side. The information that emphasized text is being presented should be vocalized when the verbosity is set to some, most, or all.</p>
 		<p>Suggested output: "emphasized text"</p>
 		<h2 id="doc-qna">doc-qna Test</h2>
 		<div role="doc-qna">This text has the role of qna.</div>
-		<p>This is a high priority. Many times the words "Questions and Answers" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to high.</p>
+		<p>This is a high priority. Many times the words "Questions and Answers" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to some, most, or all.</p>
 		<p>Suggested output: "questions and answers"</p>
 		<h2 id="doc-subtitle">doc-subtitle Test</h2>
 		<div role="doc-subtitle">This text has the role of subtitle.</div>
-		<p>This is a high priority. Many times the subtitle is present after the title. It should be vocalized when the verbosity is set to high.</p>
+		<p>This is a high priority. Many times the subtitle is present after the title. It should be vocalized when the verbosity is set to some, most, or all.</p>
 		<p>Suggested output: "subtitle"</p>
 		<h2 id="doc-tip">doc-tip Test</h2>
 		<div role="doc-tip">This text has the role of tip.</div>
-		<p>This is a high priority. Many times the word "tip" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to high.</p>
+		<p>This is a high priority. Many times the word "tip" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to some, most, or all.</p>
 		<p>Suggested output: "tip"</p>
 		<h2 id="doc-toc">doc-toc Test</h2>
 		<div role="doc-toc">This text has the role of toc.</div>
-		<p>This is a critical priority. The vocalization of the information that it is a table of contents should always be vocalized.</p>
+		<p>This is a critical priority. The vocalization of the information that it is a table of contents should always be vocalized, unless none is selected.</p>
 		<p>Suggested output: "table of contents"</p>
 		<p>This is an "actionable item" meaning the user would want to have a mechanism to go to the table of contents.</p>
 		

--- a/dpub-aria-testing/content/DPUB-ARIA-tests.xhtml
+++ b/dpub-aria-testing/content/DPUB-ARIA-tests.xhtml
@@ -10,19 +10,21 @@
 	  </header>
 	  <main>
 		<h2>Background</h2>
-		<p>Books and other publications have constructs such as chapters, parts, footnotes and more that are not commonly found on web pages. The visual presentation of these constructs makes it obvious to the sighted reader what the semantics are. These semantic constructs can now be added to HTML and XHTML by using <a href="https://www.w3.org/TR/dpub-aria-1.1/#roles">DPUB Aria roles</a> and then used for presentation through Assistive Technology. The <a href="https://www.w3.org/community/publishingcg/">Publishing Community Group</a> at the W3C continues to promote these roles for browsers, in EPUB Reading Systems, and for published digital materials.</p>
-		<p>To improve the reading experience for screen reader users, the presentation of these semantic constructs is recommended. Some of the roles are extremely important to present to the reader, while others are of less importance or a matter of reader preference. In this XHTML document, the <a href="https://daisy.org/activities/projects/ties/">Transition to Accessible EPUB working group</a> in the DAISY Consortium is making suggestions as to the importance of the roles and what might be presented. This document provides the necessary information that screen reader implementors should consider. It can also be used for testing purposes.</p>
+		<p>Books and other publications have constructs such as chapters, parts, footnotes and more that are not commonly found on web pages. The visual presentation of these constructs makes it obvious to the sighted reader what the semantics are. These document semantic constructs can now be added to HTML and XHTML by using <a href="https://www.w3.org/TR/dpub-aria-1.1/#roles">DPUB Aria roles</a> and then used for presentation through Assistive Technology. The <a href="https://www.w3.org/community/publishingcg/">Publishing Community Group</a> at the W3C continues to promote these roles for browsers, in EPUB Reading Systems, and for published digital materials.</p>
+		<p>To improve the reading experience for screen reader users, the presentation of these document semantic constructs is recommended. Some of the roles are extremely important to present to the reader, while others are of less importance or a matter of reader preference. In this XHTML document, the <a href="https://daisy.org/activities/projects/ties/">Transition to Accessible EPUB working group</a> in the DAISY Consortium is making suggestions as to the importance of the roles and what might be presented. This document provides the necessary information that screen reader implementors should consider. It can also be used for testing purposes.</p>
 		<p>Each item should be self-explanatory and indicate the (1) importance and (2) what should be presented.</p>
 		<h2>Screen Reader Implementation</h2>
 		<p>There are currently 39 DPUB Aria roles which are prefixed with "doc-" before the name of the publishing construct, e.g. <code>doc-chapter</code> for a chapter. A list of the roles, their importance, suggested output, actions to be considered, and support in browsers can be found at: <a href="https://docs.google.com/spreadsheets/d/1atUkcAbkHpS5eUJ1rdDCrQ3saY8HZEMTNtWkanASLo4/edit?usp=sharing">Google Sheet showing DPUB Aria roles and suggestions for implementors.</a>
 		</p>
 		<p>The following are presented for testing purposes. Included in the example is a description of the test, its importance, and suggested output, which corresponds to the Google sheet linked above.</p>
-		<p>Importance of vocalizing or presenting constructs:</p>
+		
+<p>The selection of the amount  of document semantics to vocalize  or present could be grouped as "all," "most", "some," or None."</p> 
+
 		<dl>
-			<dt>critical</dt><dd>should always be presented</dd>
-			<dt>high</dt><dd>should be presented most of the time</dd>
-			<dt>medium</dt><dd>should be presented some of the time</dd>
-			<dt>low</dt><dd>should be presented with the highest verbosity setting</dd>
+			<dt>critical</dt><dd>should  always be presented, unless "none" is selected.</dd>
+			<dt>high</dt><dd>should be presented when "most" is selected.</dd>
+			<dt>medium</dt><dd>should be presented when "some"   is selected.</dd>
+			<dt>low</dt><dd>should be presented     when "high" is selected.</dd>
 		</dl>
 		<h2 id="complementary">Valid Aria Role Complementary Test</h2>
 		<div role="complementary">

--- a/dpub-aria-testing/content/DPUB-ARIA-tests.xhtml
+++ b/dpub-aria-testing/content/DPUB-ARIA-tests.xhtml
@@ -5,12 +5,12 @@
 	<body>
 	  <header>
 		<h1>DPUB ARIA Test Suite</h1>
-		<p>Last updated: June 4, 2024</p>
+		<p>Last updated: June 8, 2024</p>
 <p>This test Suite has been created and is maintained by the DAISY Consortium's "Transition to Accessible EPUB" working group. To ask questions or get clarification, please use the <a href="https://github.com/daisy/transitiontoepub/issues" >issue tracker on GitHub</a>.</p>
 	  </header>
 	  <main>
 		<h2>Background</h2>
-		<p>Books and other publications have constructs such as chapters, parts, footnotes and more that are not commonly found on web pages. The visual presentation of these constructs makes it obvious to the sighted reader what the semantics are. These document semantic constructs can now be added to HTML and XHTML by using <a href="https://www.w3.org/TR/dpub-aria-1.1/#roles">DPUB Aria roles</a> and then used for presentation through Assistive Technology. The <a href="https://www.w3.org/community/publishingcg/">Publishing Community Group</a> at the W3C continues to promote these roles for browsers, in EPUB Reading Systems, and for published digital materials.</p>
+		<p>Books and other publications have constructs such as chapters, parts, footnotes and more that are not commonly found on web pages. The visual presentation of these constructs makes it obvious to the sighted reader what the document semantics are. These document semantic constructs can now be added to HTML and XHTML by using <a href="https://www.w3.org/TR/dpub-aria-1.1/#roles">DPUB Aria roles</a> and then used for presentation through Assistive Technology. The <a href="https://www.w3.org/community/publishingcg/">Publishing Community Group</a> at the W3C continues to promote these roles for browsers, in EPUB Reading Systems, and for published digital materials.</p>
 		<p>To improve the reading experience for screen reader users, the presentation of these document semantic constructs is recommended. Some of the roles are extremely important to present to the reader, while others are of less importance or a matter of reader preference. In this XHTML document, the <a href="https://daisy.org/activities/projects/ties/">Transition to Accessible EPUB working group</a> in the DAISY Consortium is making suggestions as to the importance of the roles and what might be presented. This document provides the necessary information that screen reader implementors should consider. It can also be used for testing purposes.</p>
 		<p>Each item should be self-explanatory and indicate the (1) importance and (2) what should be presented.</p>
 		<h2>Screen Reader Implementation</h2>
@@ -18,35 +18,35 @@
 		</p>
 		<p>The following are presented for testing purposes. Included in the example is a description of the test, its importance, and suggested output, which corresponds to the Google sheet linked above.</p>
 		
-<p>The selection of the amount  of document semantics to vocalize  or present could be grouped as "all," "most", "some," or None."</p> 
+<p>The document semantic verbosity i.e., selection of the amount  of document semantics to vocalize  or present, could be grouped as "all," "most", "some," or None."</p> 
 
 		<dl>
-			<dt>critical</dt><dd>should  always be presented, unless "none" is selected.</dd>
-			<dt>high</dt><dd>should be presented when "some" "most," or "all"is selected.</dd>
-			<dt>medium</dt><dd>should be presented when "most" or "all"  is selected.</dd>
-			<dt>low</dt><dd>should be presented     when "all" is selected.</dd>
+			<dt>critical</dt><dd>should  always be presented, unless the document semantic verbosity "none" is selected.</dd>
+			<dt>high</dt><dd>should be presented when the document semantic verbosity "some," "most," or "all"is selected.</dd>
+			<dt>medium</dt><dd>should be presented when the document semantic verbosity "most" or "all"  is selected.</dd>
+			<dt>low</dt><dd>should be presented     when the document semantic verbosity "all" is selected.</dd>
 		</dl>
 
-<p>Note: a verbosity selection of"some" includes critical and high importance. A verbosity selection of "most includes critical, high, and medium.</p> 
+<p>Note: a document semantic verbosity selection of "some" includes critical and high importance. A verbosity selection of "most includes critical, high, and medium.</p> 
 		<h2 id="doc-abstract">doc-abstract Test</h2>
 		<div role="doc-abstract">This text in the div element has the role of abstract.</div>
-		<p>This is a high priority. Many times the word "abstract" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to some, most, or all.</p>
+		<p>This is a high priority. Many times the word "abstract" would be included in the heading associated with this item. It should be vocalized when the document semantic verbosity is set to some, most, or all.</p>
 		<p>Suggested output: "abstract"</p>
 		<h2 id="doc-acknowledgments">doc-acknowledgments Test</h2>
 		<div role="doc-acknowledgments">This text in the <code>div</code> element has the role of acknowledgments.</div>
-		<p>This is a low priority. Many times the word "Acknowledgements" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to all.</p>
+		<p>This is a low priority. Many times the word "Acknowledgements" would be included in the heading associated with this item. It should be vocalized when the document semantic verbosity is set to all.</p>
 		<p>Suggested output: "acknowledgments"</p>
 		<h2 id="doc-afterword">doc-afterword Test</h2>
 		<div role="doc-afterword">This text in the div element has the role of afterword.</div>
-		<p>This is a medium priority. Many times the word "Afterword" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to Most or all.</p>
+		<p>This is a medium priority. Many times the word "Afterword" would be included in the heading associated with this item. It should be vocalized when the document semantic verbosity is set to Most or all.</p>
 		<p>Suggested output: "afterword"</p>
 		<h2 id="doc-appendix">doc-appendix Test</h2>
 		<div role="doc-appendix">This text in the <code>div</code> element has the role of appendix.</div>
-		<p>This is a medium priority. Many times the word "Appendix" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to most or all.</p>
+		<p>This is a medium priority. Many times the word "Appendix" would be included in the heading associated with this item. It should be vocalized when the document semantic verbosity is set to most or all.</p>
 		<p>Suggested output: "appendix"</p>
 		<h2 id="doc-backlink">doc-backlink Test</h2>
 		<a role="doc-backlink" href="#">a backlink</a>
-		<p>This is a critical priority. The vocalization of the information that it is a back link should always be vocalized, unless none is selected.</p>
+		<p>This is a critical priority. The vocalization of the information that it is a back link should always be vocalized, unless the document semantic verbosity of none is selected.</p>
 		<p>Suggested output: "back link"</p>
 		<p>This is an "actionable item" meaning the user would follow the back link to return to the identified position in the publication.</p>
 		<h2 id="doc-bibliography">doc-bibliography Test</h2>
@@ -59,40 +59,40 @@
 			</ul>
 		</section>
 		<div role="doc-bibliography">This text in the <code>div</code> element has bibliography role. Test added to check if it acts differently from role on <code>section</code> tag.</div>
-		<p>This is a medium priority. Many times the word "bibliography" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to Most or all.</p>
+		<p>This is a medium priority. Many times the word "bibliography" would be included in the heading associated with this item. It should be vocalized when the document semantic verbosity is set to Most or all.</p>
 		<p>Suggested output: "bibliography"</p>
 		<h2 id="doc-biblioref">doc-biblioref Test</h2>
 		<a role="doc-biblioref" href="#">a role of biblioref.</a>
-		<p>This is a critical priority. The vocalization of the information that it is a Bibliographic reference link should always be vocalized, unless none is selected.</p>
+		<p>This is a critical priority. The vocalization of the information that it is a Bibliographic reference link should always be vocalized, unless the document semantic verbosity of none is selected.</p>
 		<p>Suggested output: "bibliographic reference"</p>
 		<p>This is an "actionable item" meaning the user would follow the link to go to the reference identified.</p>
 		<h2 id="doc-chapter">doc-chapter Test</h2>
 		<div role="doc-chapter">This text has the  role of chapter.</div>
-		<p>This is a high priority. Many times the word "chapter" will not appear in the heading. It should be vocalized when the verbosity is set to some, most, or all.</p>
+		<p>This is a high priority. Many times the word "chapter" will not appear in the heading. It should be vocalized when the document semantic verbosity is set to some, most, or all.</p>
 		<p>Suggested output: "chapter"</p>
 		<h2 id="doc-colophon">doc-colophon Test</h2>
 		<div role="doc-colophon">This text has the role of colophon.</div>
-		<p>This is a low priority. Many times the word "colophon" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to all.</p>
+		<p>This is a low priority. Many times the word "colophon" would be included in the heading associated with this item. It should be vocalized when the document semantic verbosity is set to all.</p>
 		<p>Suggested output: "colophon"</p>
 		<h2 id="doc-conclusion">doc-conclusion Test</h2>
 		<div role="doc-conclusion">This text has the  role of conclusion.</div>
-		<p>This is a medium priority. Many times the word "conclusion" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to  most or all.</p>
+		<p>This is a medium priority. Many times the word "conclusion" would be included in the heading associated with this item. It should be vocalized when the document semantic verbosity is set to  most or all.</p>
 		<p>Suggested output: "conclusion"</p>
 		<h2 id="doc-cover">doc-cover Test</h2>
 		<img role="doc-cover" src="image_001.jpg" alt="A beautiful cover with role of cover."/>
-		<p>This is a medium priority. Many times the word "Cover" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to most or all.</p>
+		<p>This is a medium priority. Many times the word "Cover" would be included in the heading associated with this item. It should be vocalized when the document semantic verbosity is set to most or all.</p>
 		<p>Suggested output, "cover"</p>
 		<h2 id="doc-credit">doc-credit Test</h2>
 		<div role="doc-credit">This text has the role of credit.</div>
-		<p>This is a low priority. Many times the word "credit" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to all.</p>
+		<p>This is a low priority. Many times the word "credit" would be included in the heading associated with this item. It should be vocalized when the document semantic verbosity is set to all.</p>
 		<p>Suggested output: "credit"</p>
 		<h2 id="doc-credits">doc-credits Test</h2>
 		<div role="doc-credits">This text has the role of credits.</div>
-		<p>This is a low priority. Many times the word "credits" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to all.</p>
+		<p>This is a low priority. Many times the word "credits" would be included in the heading associated with this item. It should be vocalized when the document semantic verbosity is set to all.</p>
 		<p>Suggested output: "credits"</p>
 		<h2 id="doc-dedication">doc-dedication Test</h2>
 		<div role="doc-dedication">This text has the role of dedication.</div>
-		<p>This is a medium priority. Many times the word "dedication" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to most or all.</p>
+		<p>This is a medium priority. Many times the word "dedication" would be included in the heading associated with this item. It should be vocalized when the document semantic verbosity is set to most or all.</p>
 		<p>Suggested output: "dedication"</p>
 		<h2 id="doc-endnotes">doc-endnotes Tests</h2>
 		<section role="doc-endnotes">
@@ -102,106 +102,106 @@
 				<li>list item inside endnotes</li>
 				<li>second list item inside endnotes</li>
 			</ul>
-			<p>This is a critical priority. Many times the word "end notes" would be included in the heading associated with this item. It should be vocalized all of the time, unless none is selected. </p>
+			<p>This is a critical priority. Many times the word "end notes" would be included in the heading associated with this item. It should be vocalized all of the time, unless the document semantic verbosity   of  none is selected. </p>
 			<p>Suggested output: "endnotes"</p>
 		</section>
 		<div role="doc-endnotes">This text in the <code>div</code> element has the endnotes role. Test added to check if it acts differently from role on <code>section</code> tag.</div>
 		<h2 id="doc-epigraph">doc-epigraph Test</h2>
 		<div role="doc-epigraph">This text has the role of epigraph.</div>
-		<p>This is a low priority. Many times the word "epigraph" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to all.</p>
+		<p>This is a low priority. Many times the word "epigraph" would be included in the heading associated with this item. It should be vocalized when the document semantic verbosity is set to all.</p>
 		<p>Suggested output: "epigraph"</p>
 		<h2 id="doc-epilogue">doc-epilogue Test</h2>
 		<div role="doc-epilogue">This test has the role of epilogue.</div>
-		<p>This is a medium priority. Many times the word "epilogue" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to most or all.</p>
+		<p>This is a medium priority. Many times the word "epilogue" would be included in the heading associated with this item. It should be vocalized when the document semantic verbosity is set to most or all.</p>
 		<p>Suggested output: "epilogue"</p>
 		<h2 id="doc-errata">doc-errata Test</h2>
 		<div role="doc-errata">This text has the role of errata.</div>
-		<p>This is a low priority. Many times the word "errata" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to all.</p>
+		<p>This is a low priority. Many times the word "errata" would be included in the heading associated with this item. It should be vocalized when the document semantic verbosity is set to all.</p>
 		<p>Suggested output: "errata"</p>
 		<h2 id="doc-example">doc-example Test</h2>
 		<div role="doc-example">This text has the role of example.</div>
-		<p>This is a medium priority. Many times the word "example" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to most or all.</p>
+		<p>This is a medium priority. Many times the word "example" would be included in the heading associated with this item. It should be vocalized when the document semantic verbosity is set to most or all.</p>
 		<p>Suggested output: "example"</p>
 		<h2 id="doc-footnote">doc-footnote Test</h2>
 		<div role="doc-footnote">This text has the role of footnote.</div>
-		<p>This is a critical priority. Many times the word "footnote" would be included in the heading associated with this item. It should always be vocalized, unless none is selected.</p>
+		<p>This is a critical priority. Many times the word "footnote" would be included in the heading associated with this item. It should always be vocalized, unless the document semantic  verbosity of none is selected.</p>
 		<p>Suggested output: "footnote"</p>
 		<h2 id="doc-foreword">doc-foreword Test</h2>
 		<div role="doc-foreword">This text has the role of foreword.</div>
-		<p>This is a medium priority. Many times the word "foreword" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to most or all.</p>
+		<p>This is a medium priority. Many times the word "foreword" would be included in the heading associated with this item. It should be vocalized when the document semantic verbosity is set to most or all.</p>
 		<p>Suggested output: "foreword"</p>
 		<h2 id="doc-glossary">doc-glossary Test</h2>
 		<div role="doc-glossary">
 			This text has the role of glossary.
-			<p>This is a medium priority. Many times the word "glossary" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to most or all.</p>
+			<p>This is a medium priority. Many times the word "glossary" would be included in the heading associated with this item. It should be vocalized when the document semantic verbosity is set to most or all.</p>
 			<p>Suggested output: "glossary"</p>
 			<span role="term">foo role of term.</span>: <span role="definition">bar role of definition.</span>
 		</div>
 		<h2 id="doc-glossref">doc-glossref Test</h2>
 		<a role="doc-glossref" href="#">a glossary reference</a>
-		<p>This is a critical priority. The vocalization of the information that it is a glossary reference link should always be vocalized, unless none is selected.</p>
+		<p>This is a critical priority. The vocalization of the information that it is a glossary reference link should always be vocalized, unless the document semantic  verbosity of none is selected.</p>
 		<p>Suggested output: "glossary reference"</p>
 		<p>This is an "actionable item" meaning the user would follow the link to go to the reference identified.</p>
 		<h2 id="doc-index">doc-index Test</h2>
 		<div role="doc-index">This text has the role of index.</div>
-		<p>This is a medium priority. Many times the word "index" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to Most or all.</p>
+		<p>This is a medium priority. Many times the word "index" would be included in the heading associated with this item. It should be vocalized when the document semantic verbosity is set to Most or all.</p>
 		<p>Suggested output: "index"</p>
 		<h2 id="doc-introduction">doc-introduction Test</h2>
 		<div role="doc-introduction">This text has the role of introduction.</div>
-		<p>This is a medium priority. Many times the word "introduction" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to most or all.</p>
+		<p>This is a medium priority. Many times the word "introduction" would be included in the heading associated with this item. It should be vocalized when the document semantic verbosity is set to most or all.</p>
 		<p>Suggested output: "introduction"</p>
 		<h2 id="doc-noteref">doc-noteref Test</h2>
 		<a role="doc-noteref" href="#">a note reference</a>
-		<p>This is a critical priority. The vocalization of the information that it is a note reference link should always be vocalized, unless none is selected.</p>
+		<p>This is a critical priority. The vocalization of the information that it is a note reference link should always be vocalized, unless the document semantic verbosity of none is selected.</p>
 		<p>Suggested output: "note reference"</p>
 		<p>This is an "actionable item" meaning the user would follow the link to go to the reference identified.</p>
 		<h2 id="doc-notice">doc-notice Test</h2>
 		<div role="doc-notice">This text has the role of notice.</div>
 		<p>This is a high priority. 
-			the word "notice or caution" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to some, most, or all.
+			the word "notice or caution" would be included in the heading associated with this item. It should be vocalized when the document semantic verbosity is set to some, most, or all.
 		</p>
 		<p>Suggested output: "notice"</p>
 		<h2 id="doc-pagebreak">doc-pagebreak Test</h2>
 		<p>In this text there is a pagebreak <span role="doc-pagebreak" aria-label="23" />.</p>
-		<p>This is a critical priority. The vocalization of the information that it is a page break should always be vocalized, unless none is selected.</p>
+		<p>This is a critical priority. The vocalization of the information that it is a page break should always be vocalized, unless the document semantic verbosity of none is selected.</p>
 		<p>Suggested output: "page break"</p>
-		<p>This is an "actionable item" meaning the user would want to go to the previous or next page break. This is an excellent candidate for single letter navigation and the letter <kbd>p</kbd> is suggested. </p>
+		<p>This is an "actionable item" meaning the user would want to go to the previous or next page break. This is an excellent candidate for single letter navigation .</p>
 		<h2 id="doc-pagelist">doc-pagelist Test</h2>
 		<div role="doc-pagelist">This text has the role of pagelist.</div>
-		<p>This is a critical priority. The vocalization of the information that it is a list of links to pages should always be vocalized, unless none is selected.</p>
+		<p>This is a critical priority. The vocalization of the information that it is a list of links to pages should always be vocalized, unless the document semantic verbosity of none is selected.</p>
 		<p>Suggested output: "list of pages"</p>
 		<p>This is an "actionable item" meaning the user would want to be taken to the list of pages or if they were presented with a list of pages, it would be announced.</p>
 		<h2 id="doc-part">doc-part Test</h2>
 		<div role="doc-part">This text has the role of part.</div>
-		<p>This is a high priority. Many times the word "part" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to most, some, or all .</p>
+		<p>This is a high priority. Many times the word "part" would be included in the heading associated with this item. It should be vocalized when the document semantic verbosity is set to most, some, or all .</p>
 		<p>Suggested output: "part"</p>
 		<h2 id="doc-preface">doc-preface Test</h2>
 		<div role="doc-preface">This text has the role of preface.</div>
-		<p>This is a medium priority. Many times the word "preface" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to most  or all.</p>
+		<p>This is a medium priority. Many times the word "preface" would be included in the heading associated with this item. It should be vocalized when the document semantic verbosity is set to most  or all.</p>
 		<p>Suggested output: "preface"</p>
 		<h2 id="doc-prologue">doc-prologue Test</h2>
 		<div role="doc-prologue">This text has the role of prologue.</div>
-		<p>This is a medium priority. Many times the word "prolog" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to most or all.</p>
+		<p>This is a medium priority. Many times the word "prolog" would be included in the heading associated with this item. It should be vocalized when the document semantic verbosity is set to most or all.</p>
 		<p>Suggested output: "prolog"</p>
 		<h2 id="doc-pullquote">doc-pullquote Test</h2>
 		<div role="doc-pullquote">This text has the role of pullquote.</div>
-		<p>This is a high priority. Many times emphasized portions of  text are in a margin or pulled to the side. The information that emphasized text is being presented should be vocalized when the verbosity is set to some, most, or all.</p>
+		<p>This is a high priority. Many times emphasized portions of  text are in a margin or pulled to the side. The information that emphasized text is being presented should be vocalized when the document semantic verbosity is set to some, most, or all.</p>
 		<p>Suggested output: "emphasized text"</p>
 		<h2 id="doc-qna">doc-qna Test</h2>
 		<div role="doc-qna">This text has the role of qna.</div>
-		<p>This is a high priority. Many times the words "Questions and Answers" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to some, most, or all.</p>
+		<p>This is a high priority. Many times the words "Questions and Answers" would be included in the heading associated with this item. It should be vocalized when the document semantic verbosity is set to some, most, or all.</p>
 		<p>Suggested output: "questions and answers"</p>
 		<h2 id="doc-subtitle">doc-subtitle Test</h2>
 		<div role="doc-subtitle">This text has the role of subtitle.</div>
-		<p>This is a high priority. Many times the subtitle is present after the title. It should be vocalized when the verbosity is set to some, most, or all.</p>
+		<p>This is a high priority. Many times the subtitle is present after the title. It should be vocalized when the document semantic verbosity is set to some, most, or all.</p>
 		<p>Suggested output: "subtitle"</p>
 		<h2 id="doc-tip">doc-tip Test</h2>
 		<div role="doc-tip">This text has the role of tip.</div>
-		<p>This is a high priority. Many times the word "tip" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to some, most, or all.</p>
+		<p>This is a high priority. Many times the word "tip" would be included in the heading associated with this item. It should be vocalized when the document semantic verbosity is set to some, most, or all.</p>
 		<p>Suggested output: "tip"</p>
 		<h2 id="doc-toc">doc-toc Test</h2>
 		<div role="doc-toc">This text has the role of toc.</div>
-		<p>This is a critical priority. The vocalization of the information that it is a table of contents should always be vocalized, unless none is selected.</p>
+		<p>This is a critical priority. The vocalization of the information that it is a table of contents should always be vocalized, unless the document semantic verbosity of none is selected.</p>
 		<p>Suggested output: "table of contents"</p>
 		<p>This is an "actionable item" meaning the user would want to have a mechanism to go to the table of contents.</p>
 		

--- a/dpub-aria-testing/content/DPUB-ARIA-tests.xhtml
+++ b/dpub-aria-testing/content/DPUB-ARIA-tests.xhtml
@@ -26,10 +26,7 @@
 			<dt>medium</dt><dd>should be presented when "some" or "all"  is selected.</dd>
 			<dt>low</dt><dd>should be presented     when "all" is selected.</dd>
 		</dl>
-		<h2 id="complementary">Valid Aria Role Complementary Test</h2>
-		<div role="complementary">
-			This text in a <code>div</code> element has the  role of complementary.
-		</div>
+
 		<h2 id="doc-abstract">doc-abstract Test</h2>
 		<div role="doc-abstract">This text in the div element has the role of abstract.</div>
 		<p>This is a high priority. Many times the word "abstract" would be included in the heading associated with this item. It should be vocalized when the verbosity is set to high.</p>
@@ -206,8 +203,17 @@
 		<p>This is a critical priority. The vocalization of the information that it is a table of contents should always be vocalized.</p>
 		<p>Suggested output: "table of contents"</p>
 		<p>This is an "actionable item" meaning the user would want to have a mechanism to go to the table of contents.</p>
-		<h2 id="doc-fake">doc-fake Test</h2>
+		
+<h2>Tests to make sure nothing is voiced</h2>
+
+<p>The next two tests should not be voiced through the DPUB ARIA roles. They are placed here only for testing purposes.</p>
+
+<h2 id="doc-fake">doc-fake Test</h2>
 		<div role="doc-fake">This text has the role of fake which should not map to anything other than generic.</div>
+		<h2 id="complementary">Valid Aria Role Complementary Test</h2>
+		<div role="complementary">
+			This text in a <code>div</code> element has the  role of complementary.
+		</div>
 	  </main>
 	</body>
 </html>

--- a/dpub-aria-testing/content/DPUB-ARIA-tests.xhtml
+++ b/dpub-aria-testing/content/DPUB-ARIA-tests.xhtml
@@ -22,9 +22,9 @@
 
 		<dl>
 			<dt>critical</dt><dd>should  always be presented, unless "none" is selected.</dd>
-			<dt>high</dt><dd>should be presented when "most" is selected.</dd>
-			<dt>medium</dt><dd>should be presented when "some"   is selected.</dd>
-			<dt>low</dt><dd>should be presented     when "high" is selected.</dd>
+			<dt>high</dt><dd>should be presented when "some" "most," or "all"is selected.</dd>
+			<dt>medium</dt><dd>should be presented when "some" or "all"  is selected.</dd>
+			<dt>low</dt><dd>should be presented     when "all" is selected.</dd>
 		</dl>
 		<h2 id="complementary">Valid Aria Role Complementary Test</h2>
 		<div role="complementary">

--- a/dpub-aria-testing/content/DPUB-ARIA-tests.xhtml
+++ b/dpub-aria-testing/content/DPUB-ARIA-tests.xhtml
@@ -6,6 +6,7 @@
 	  <header>
 		<h1>DPUB ARIA Test Suite</h1>
 		<p>Last updated: June 4, 2024</p>
+<p>This test Suite has been created and is maintained by the DAISY Consortium's "Transition to Accessible EPUB" working group. To ask questions or get clarification, please use the <a href="https://github.com/daisy/transitiontoepub/issues" >issue tracker on GitHub</a>.</p>
 	  </header>
 	  <main>
 		<h2>Background</h2>


### PR DESCRIPTION
Following the TIES call on June 4, I made the suggested changes. I tried to make separate commits for the various parts. I hope it came out like that!

1. Added a link to our issue tracker for communications.
2. Added more clarification about verbosity. I decided to continue to use that word and associate it with all, most, some, and none.
3. In each entry I reference all, most, some, or none, and I added all that applied, i.e. high is some, most, and all, and medium is some and all.
4. I moved the complementary to the end and noted why it is there.
5. I changed the spelling of acknowledgments to mach the doc-acknowledgment. Note that in the DPUB aria specification that we mix US English and British English speling. Prolog is US and prologue is British, and epilog is us and epilogue is British.