### PR TITLE
Glossary and links not live added

### DIFF
--- a/dpub-aria-testing/content/DPUB-ARIA-tests.xhtml
+++ b/dpub-aria-testing/content/DPUB-ARIA-tests.xhtml
@@ -28,6 +28,8 @@
 		</dl>
 
 <p>Note: a document semantic verbosity selection of "some" includes critical and high importance. A verbosity selection of "most includes critical, high, and medium.</p> 
+
+<p>Note: The links and references are not live, meaning that following the reference will not move to that location. The references are for testing vocalization only</p>
 		<h2 id="doc-abstract">doc-abstract Test</h2>
 		<div role="doc-abstract">This text in the div element has the role of abstract.</div>
 		<p>This is a high priority. Many times the word "abstract" would be included in the heading associated with this item. It should be vocalized when the document semantic verbosity is set to some, most, or all.</p>

--- a/dpub-aria-testing/content/DPUB-ARIA-tests.xhtml
+++ b/dpub-aria-testing/content/DPUB-ARIA-tests.xhtml
@@ -130,13 +130,17 @@
 		<div role="doc-foreword">This text has the role of foreword.</div>
 		<p>This is a medium priority. Many times the word "foreword" would be included in the heading associated with this item. It should be vocalized when the document semantic verbosity is set to most or all.</p>
 		<p>Suggested output: "foreword"</p>
-		<h2 id="doc-glossary">doc-glossary Test</h2>
-		<div role="doc-glossary">
-			This text has the role of glossary.
-			<p>This is a medium priority. Many times the word "glossary" would be included in the heading associated with this item. It should be vocalized when the document semantic verbosity is set to most or all.</p>
-			<p>Suggested output: "glossary"</p>
-			<span role="term">foo role of term.</span>: <span role="definition">bar role of definition.</span>
-		</div>
+                             <h2 id="doc-glossary">doc-glossary Test</h2>
+                             <div role="doc-glossary">
+                                           This text has the role of glossary.
+<ul>
+                                           <li><span role="term">foo role of term.</span>: <span role="definition">bar role of definition.</span></li>
+</ul>
+                             </div>
+                                           <p>This is a medium priority. Many times the word "glossary" would be included in the heading associated with this item. It should be vocalized when the document semantic verbosity is set to most or all.</p>
+                                           <p>Suggested output: "glossary"</p>
+
+
 		<h2 id="doc-glossref">doc-glossref Test</h2>
 		<a role="doc-glossref" href="#">a glossary reference</a>
 		<p>This is a critical priority. The vocalization of the information that it is a glossary reference link should always be vocalized, unless the document semantic  verbosity of none is selected.</p>


### PR DESCRIPTION
I pasted in the suggestion from Avneesh. The only change there was to ad a ul and li for the term. This is similar to the bibliography.

Also added a paragraph that the links and references are not live.

This will also mean that Gregorio's build of theEPUB should be updated.