### PR TITLE
list of 948 math symbols in UTF-8

### DIFF
--- a/symbols-list/math-role-UTF8-list.html
+++ b/symbols-list/math-role-UTF8-list.html
@@ -20,954 +20,954 @@
 			Each line contains the unicode with role math followed up by the symbol in text and the name of the symbol. 
 		</p>
 		<ul>
-      <li><span class="unicode" role="math">&#x002B</span><span class="text">+</span><span class="name">Plus Sign</li>
-        <li><span class="unicode" role="math">&#x003C</span><span class="text"><</span><span class="name">Less-Than Sign</li>
-        <li><span class="unicode" role="math">&#x003D</span><span class="text">=</span><span class="name">Equals Sign</li>
-        <li><span class="unicode" role="math">&#x003E</span><span class="text">></span><span class="name">Greater-Than Sign</li>
-        <li><span class="unicode" role="math">&#x007C</span><span class="text">|</span><span class="name">Vertical Line</li>
-        <li><span class="unicode" role="math">&#x007E</span><span class="text">~</span><span class="name">Tilde</li>
-        <li><span class="unicode" role="math">&#x00AC</span><span class="text">¬</span><span class="name">Not Sign</li>
-        <li><span class="unicode" role="math">&#x00B1</span><span class="text">±</span><span class="name">Plus-Minus Sign</li>
-        <li><span class="unicode" role="math">&#x00D7</span><span class="text">×</span><span class="name">Multiplication Sign</li>
-        <li><span class="unicode" role="math">&#x00F7</span><span class="text">÷</span><span class="name">Division Sign</li>
-        <li><span class="unicode" role="math">&#x03F6</span><span class="text">϶</span><span class="name">Greek Reversed Lunate Epsilon Symbol</li>
-        <li><span class="unicode" role="math">&#x0606</span><span class="text">؆</span><span class="name">Arabic-Indic Cube Root</li>
-        <li><span class="unicode" role="math">&#x0607</span><span class="text">؇</span><span class="name">Arabic-Indic Fourth Root</li>
-        <li><span class="unicode" role="math">&#x0608</span><span class="text">؈</span><span class="name">Arabic Ray</li>
-        <li><span class="unicode" role="math">&#x2044</span><span class="text">⁄</span><span class="name">Fraction Slash</li>
-        <li><span class="unicode" role="math">&#x2052</span><span class="text">⁒</span><span class="name">Commercial Minus Sign</li>
-        <li><span class="unicode" role="math">&#x207A</span><span class="text">⁺</span><span class="name">Superscript Plus Sign</li>
-        <li><span class="unicode" role="math">&#x207B</span><span class="text">⁻</span><span class="name">Superscript Minus</li>
-        <li><span class="unicode" role="math">&#x207C</span><span class="text">⁼</span><span class="name">Superscript Equals Sign</li>
-        <li><span class="unicode" role="math">&#x208A</span><span class="text">₊</span><span class="name">Subscript Plus Sign</li>
-        <li><span class="unicode" role="math">&#x208B</span><span class="text">₋</span><span class="name">Subscript Minus</li>
-        <li><span class="unicode" role="math">&#x208C</span><span class="text">₌</span><span class="name">Subscript Equals Sign</li>
-        <li><span class="unicode" role="math">&#x2118</span><span class="text">℘</span><span class="name">Script Capital P</li>
-        <li><span class="unicode" role="math">&#x2140</span><span class="text">⅀</span><span class="name">Double-Struck N-Ary Summation</li>
-        <li><span class="unicode" role="math">&#x2141</span><span class="text">⅁</span><span class="name">Turned Sans-Serif Capital G</li>
-        <li><span class="unicode" role="math">&#x2142</span><span class="text">⅂</span><span class="name">Turned Sans-Serif Capital L</li>
-        <li><span class="unicode" role="math">&#x2143</span><span class="text">⅃</span><span class="name">Reversed Sans-Serif Capital L</li>
-        <li><span class="unicode" role="math">&#x2144</span><span class="text">⅄</span><span class="name">Turned Sans-Serif Capital Y</li>
-        <li><span class="unicode" role="math">&#x214B</span><span class="text">⅋</span><span class="name">Turned Ampersand</li>
-        <li><span class="unicode" role="math">&#x2190</span><span class="text">←</span><span class="name">Leftwards Arrow</li>
-        <li><span class="unicode" role="math">&#x2191</span><span class="text">↑</span><span class="name">Upwards Arrow</li>
-        <li><span class="unicode" role="math">&#x2192</span><span class="text">→</span><span class="name">Rightwards Arrow</li>
-        <li><span class="unicode" role="math">&#x2193</span><span class="text">↓</span><span class="name">Downwards Arrow</li>
-        <li><span class="unicode" role="math">&#x2194</span><span class="text">↔</span><span class="name">Left Right Arrow</li>
-        <li><span class="unicode" role="math">&#x219A</span><span class="text">↚</span><span class="name">Leftwards Arrow with Stroke</li>
-        <li><span class="unicode" role="math">&#x219B</span><span class="text">↛</span><span class="name">Rightwards Arrow with Stroke</li>
-        <li><span class="unicode" role="math">&#x21A0</span><span class="text">↠</span><span class="name">Rightwards Two Headed Arrow</li>
-        <li><span class="unicode" role="math">&#x21A3</span><span class="text">↣</span><span class="name">Rightwards Arrow with Tail</li>
-        <li><span class="unicode" role="math">&#x21A6</span><span class="text">↦</span><span class="name">Rightwards Arrow from Bar</li>
-        <li><span class="unicode" role="math">&#x21AE</span><span class="text">↮</span><span class="name">Left Right Arrow with Stroke</li>
-        <li><span class="unicode" role="math">&#x21CE</span><span class="text">⇎</span><span class="name">Left Right Double Arrow with Stroke</li>
-        <li><span class="unicode" role="math">&#x21CF</span><span class="text">⇏</span><span class="name">Rightwards Double Arrow with Stroke</li>
-        <li><span class="unicode" role="math">&#x21D2</span><span class="text">⇒</span><span class="name">Rightwards Double Arrow</li>
-        <li><span class="unicode" role="math">&#x21D4</span><span class="text">⇔</span><span class="name">Left Right Double Arrow</li>
-        <li><span class="unicode" role="math">&#x21F4</span><span class="text">⇴</span><span class="name">Right Arrow with Small Circle</li>
-        <li><span class="unicode" role="math">&#x21F5</span><span class="text">⇵</span><span class="name">Downwards Arrow Leftwards of Upwards Arrow</li>
-        <li><span class="unicode" role="math">&#x21F6</span><span class="text">⇶</span><span class="name">Three Rightwards Arrows</li>
-        <li><span class="unicode" role="math">&#x21F7</span><span class="text">⇷</span><span class="name">Leftwards Arrow with Vertical Stroke</li>
-        <li><span class="unicode" role="math">&#x21F8</span><span class="text">⇸</span><span class="name">Rightwards Arrow with Vertical Stroke</li>
-        <li><span class="unicode" role="math">&#x21F9</span><span class="text">⇹</span><span class="name">Left Right Arrow with Vertical Stroke</li>
-        <li><span class="unicode" role="math">&#x21FA</span><span class="text">⇺</span><span class="name">Leftwards Arrow with Double Vertical Stroke</li>
-        <li><span class="unicode" role="math">&#x21FB</span><span class="text">⇻</span><span class="name">Rightwards Arrow with Double Vertical Stroke</li>
-        <li><span class="unicode" role="math">&#x21FC</span><span class="text">⇼</span><span class="name">Left Right Arrow with Double Vertical Stroke</li>
-        <li><span class="unicode" role="math">&#x21FD</span><span class="text">⇽</span><span class="name">Leftwards Open-Headed Arrow</li>
-        <li><span class="unicode" role="math">&#x21FE</span><span class="text">⇾</span><span class="name">Rightwards Open-Headed Arrow</li>
-        <li><span class="unicode" role="math">&#x21FF</span><span class="text">⇿</span><span class="name">Left Right Open-Headed Arrow</li>
-        <li><span class="unicode" role="math">&#x2200</span><span class="text">∀</span><span class="name">For All</li>
-        <li><span class="unicode" role="math">&#x2201</span><span class="text">∁</span><span class="name">Complement</li>
-        <li><span class="unicode" role="math">&#x2202</span><span class="text">∂</span><span class="name">Partial Differential</li>
-        <li><span class="unicode" role="math">&#x2203</span><span class="text">∃</span><span class="name">There Exists</li>
-        <li><span class="unicode" role="math">&#x2204</span><span class="text">∄</span><span class="name">There Does Not Exist</li>
-        <li><span class="unicode" role="math">&#x2205</span><span class="text">∅</span><span class="name">Empty Set</li>
-        <li><span class="unicode" role="math">&#x2206</span><span class="text">∆</span><span class="name">Increment</li>
-        <li><span class="unicode" role="math">&#x2207</span><span class="text">∇</span><span class="name">Nabla</li>
-        <li><span class="unicode" role="math">&#x2208</span><span class="text">∈</span><span class="name">Element Of</li>
-        <li><span class="unicode" role="math">&#x2209</span><span class="text">∉</span><span class="name">Not An Element Of</li>
-        <li><span class="unicode" role="math">&#x220A</span><span class="text">∊</span><span class="name">Small Element Of</li>
-        <li><span class="unicode" role="math">&#x220B</span><span class="text">∋</span><span class="name">Contains as Member</li>
-        <li><span class="unicode" role="math">&#x220C</span><span class="text">∌</span><span class="name">Does Not Contain as Member</li>
-        <li><span class="unicode" role="math">&#x220D</span><span class="text">∍</span><span class="name">Small Contains as Member</li>
-        <li><span class="unicode" role="math">&#x220E</span><span class="text">∎</span><span class="name">End of Proof</li>
-        <li><span class="unicode" role="math">&#x220F</span><span class="text">∏</span><span class="name">N-Ary Product</li>
-        <li><span class="unicode" role="math">&#x2210</span><span class="text">∐</span><span class="name">N-Ary Coproduct</li>
-        <li><span class="unicode" role="math">&#x2211</span><span class="text">∑</span><span class="name">N-Ary Summation</li>
-        <li><span class="unicode" role="math">&#x2212</span><span class="text">−</span><span class="name">Minus Sign</li>
-        <li><span class="unicode" role="math">&#x2213</span><span class="text">∓</span><span class="name">Minus-or-Plus Sign</li>
-        <li><span class="unicode" role="math">&#x2214</span><span class="text">∔</span><span class="name">Dot Plus</li>
-        <li><span class="unicode" role="math">&#x2215</span><span class="text">∕</span><span class="name">Division Slash</li>
-        <li><span class="unicode" role="math">&#x2216</span><span class="text">∖</span><span class="name">Set Minus</li>
-        <li><span class="unicode" role="math">&#x2217</span><span class="text">∗</span><span class="name">Asterisk Operator</li>
-        <li><span class="unicode" role="math">&#x2218</span><span class="text">∘</span><span class="name">Ring Operator</li>
-        <li><span class="unicode" role="math">&#x2219</span><span class="text">∙</span><span class="name">Bullet Operator</li>
-        <li><span class="unicode" role="math">&#x221A</span><span class="text">√</span><span class="name">Square Root</li>
-        <li><span class="unicode" role="math">&#x221B</span><span class="text">∛</span><span class="name">Cube Root</li>
-        <li><span class="unicode" role="math">&#x221C</span><span class="text">∜</span><span class="name">Fourth Root</li>
-        <li><span class="unicode" role="math">&#x221D</span><span class="text">∝</span><span class="name">Proportional To</li>
-        <li><span class="unicode" role="math">&#x221E</span><span class="text">∞</span><span class="name">Infinity</li>
-        <li><span class="unicode" role="math">&#x221F</span><span class="text">∟</span><span class="name">Right Angle</li>
-        <li><span class="unicode" role="math">&#x2220</span><span class="text">∠</span><span class="name">Angle</li>
-        <li><span class="unicode" role="math">&#x2221</span><span class="text">∡</span><span class="name">Measured Angle</li>
-        <li><span class="unicode" role="math">&#x2222</span><span class="text">∢</span><span class="name">Spherical Angle</li>
-        <li><span class="unicode" role="math">&#x2223</span><span class="text">∣</span><span class="name">Divides</li>
-        <li><span class="unicode" role="math">&#x2224</span><span class="text">∤</span><span class="name">Does Not Divide</li>
-        <li><span class="unicode" role="math">&#x2225</span><span class="text">∥</span><span class="name">Parallel To</li>
-        <li><span class="unicode" role="math">&#x2226</span><span class="text">∦</span><span class="name">Not Parallel To</li>
-        <li><span class="unicode" role="math">&#x2227</span><span class="text">∧</span><span class="name">Logical And</li>
-        <li><span class="unicode" role="math">&#x2228</span><span class="text">∨</span><span class="name">Logical Or</li>
-        <li><span class="unicode" role="math">&#x2229</span><span class="text">∩</span><span class="name">Intersection</li>
-        <li><span class="unicode" role="math">&#x222A</span><span class="text">∪</span><span class="name">Union</li>
-        <li><span class="unicode" role="math">&#x222B</span><span class="text">∫</span><span class="name">Integral</li>
-        <li><span class="unicode" role="math">&#x222C</span><span class="text">∬</span><span class="name">Double Integral</li>
-        <li><span class="unicode" role="math">&#x222D</span><span class="text">∭</span><span class="name">Triple Integral</li>
-        <li><span class="unicode" role="math">&#x222E</span><span class="text">∮</span><span class="name">Contour Integral</li>
-        <li><span class="unicode" role="math">&#x222F</span><span class="text">∯</span><span class="name">Surface Integral</li>
-        <li><span class="unicode" role="math">&#x2230</span><span class="text">∰</span><span class="name">Volume Integral</li>
-        <li><span class="unicode" role="math">&#x2231</span><span class="text">∱</span><span class="name">Clockwise Integral</li>
-        <li><span class="unicode" role="math">&#x2232</span><span class="text">∲</span><span class="name">Clockwise Contour Integral</li>
-        <li><span class="unicode" role="math">&#x2233</span><span class="text">∳</span><span class="name">Anticlockwise Contour Integral</li>
-        <li><span class="unicode" role="math">&#x2234</span><span class="text">∴</span><span class="name">Therefore</li>
-        <li><span class="unicode" role="math">&#x2235</span><span class="text">∵</span><span class="name">Because</li>
-        <li><span class="unicode" role="math">&#x2236</span><span class="text">∶</span><span class="name">Ratio</li>
-        <li><span class="unicode" role="math">&#x2237</span><span class="text">∷</span><span class="name">Proportion</li>
-        <li><span class="unicode" role="math">&#x2238</span><span class="text">∸</span><span class="name">Dot Minus</li>
-        <li><span class="unicode" role="math">&#x2239</span><span class="text">∹</span><span class="name">Excess</li>
-        <li><span class="unicode" role="math">&#x223A</span><span class="text">∺</span><span class="name">Geometric Proportion</li>
-        <li><span class="unicode" role="math">&#x223B</span><span class="text">∻</span><span class="name">Homothetic</li>
-        <li><span class="unicode" role="math">&#x223C</span><span class="text">∼</span><span class="name">Tilde Operator</li>
-        <li><span class="unicode" role="math">&#x223D</span><span class="text">∽</span><span class="name">Reversed Tilde</li>
-        <li><span class="unicode" role="math">&#x223E</span><span class="text">∾</span><span class="name">Inverted Lazy S</li>
-        <li><span class="unicode" role="math">&#x223F</span><span class="text">∿</span><span class="name">Sine Wave</li>
-        <li><span class="unicode" role="math">&#x2240</span><span class="text">≀</span><span class="name">Wreath Product</li>
-        <li><span class="unicode" role="math">&#x2241</span><span class="text">≁</span><span class="name">Not Tilde</li>
-        <li><span class="unicode" role="math">&#x2242</span><span class="text">≂</span><span class="name">Minus Tilde</li>
-        <li><span class="unicode" role="math">&#x2243</span><span class="text">≃</span><span class="name">Asymptotically Equal To</li>
-        <li><span class="unicode" role="math">&#x2244</span><span class="text">≄</span><span class="name">Not Asymptotically Equal To</li>
-        <li><span class="unicode" role="math">&#x2245</span><span class="text">≅</span><span class="name">Approximately Equal To</li>
-        <li><span class="unicode" role="math">&#x2246</span><span class="text">≆</span><span class="name">Approximately But Not Actually Equal To</li>
-        <li><span class="unicode" role="math">&#x2247</span><span class="text">≇</span><span class="name">Neither Approximately Nor Actually Equal To</li>
-        <li><span class="unicode" role="math">&#x2248</span><span class="text">≈</span><span class="name">Almost Equal To</li>
-        <li><span class="unicode" role="math">&#x2249</span><span class="text">≉</span><span class="name">Not Almost Equal To</li>
-        <li><span class="unicode" role="math">&#x224A</span><span class="text">≊</span><span class="name">Almost Equal or Equal To</li>
-        <li><span class="unicode" role="math">&#x224B</span><span class="text">≋</span><span class="name">Triple Tilde</li>
-        <li><span class="unicode" role="math">&#x224C</span><span class="text">≌</span><span class="name">All Equal To</li>
-        <li><span class="unicode" role="math">&#x224D</span><span class="text">≍</span><span class="name">Equivalent To</li>
-        <li><span class="unicode" role="math">&#x224E</span><span class="text">≎</span><span class="name">Geometrically Equivalent To</li>
-        <li><span class="unicode" role="math">&#x224F</span><span class="text">≏</span><span class="name">Difference Between</li>
-        <li><span class="unicode" role="math">&#x2250</span><span class="text">≐</span><span class="name">Approaches the Limit</li>
-        <li><span class="unicode" role="math">&#x2251</span><span class="text">≑</span><span class="name">Geometrically Equal To</li>
-        <li><span class="unicode" role="math">&#x2252</span><span class="text">≒</span><span class="name">Approximately Equal to or the Image Of</li>
-        <li><span class="unicode" role="math">&#x2253</span><span class="text">≓</span><span class="name">Image of or Approximately Equal To</li>
-        <li><span class="unicode" role="math">&#x2254</span><span class="text">≔</span><span class="name">Colon Equals</li>
-        <li><span class="unicode" role="math">&#x2255</span><span class="text">≕</span><span class="name">Equals Colon</li>
-        <li><span class="unicode" role="math">&#x2256</span><span class="text">≖</span><span class="name">Ring In Equal To</li>
-        <li><span class="unicode" role="math">&#x2257</span><span class="text">≗</span><span class="name">Ring Equal To</li>
-        <li><span class="unicode" role="math">&#x2258</span><span class="text">≘</span><span class="name">Corresponds To</li>
-        <li><span class="unicode" role="math">&#x2259</span><span class="text">≙</span><span class="name">Estimates</li>
-        <li><span class="unicode" role="math">&#x225A</span><span class="text">≚</span><span class="name">Equiangular To</li>
-        <li><span class="unicode" role="math">&#x225B</span><span class="text">≛</span><span class="name">Star Equals</li>
-        <li><span class="unicode" role="math">&#x225C</span><span class="text">≜</span><span class="name">Delta Equal To</li>
-        <li><span class="unicode" role="math">&#x225D</span><span class="text">≝</span><span class="name">Equal to By Definition</li>
-        <li><span class="unicode" role="math">&#x225E</span><span class="text">≞</span><span class="name">Measured By</li>
-        <li><span class="unicode" role="math">&#x225F</span><span class="text">≟</span><span class="name">Questioned Equal To</li>
-        <li><span class="unicode" role="math">&#x2260</span><span class="text">≠</span><span class="name">Not Equal To</li>
-        <li><span class="unicode" role="math">&#x2261</span><span class="text">≡</span><span class="name">Identical To</li>
-        <li><span class="unicode" role="math">&#x2262</span><span class="text">≢</span><span class="name">Not Identical To</li>
-        <li><span class="unicode" role="math">&#x2263</span><span class="text">≣</span><span class="name">Strictly Equivalent To</li>
-        <li><span class="unicode" role="math">&#x2264</span><span class="text">≤</span><span class="name">Less-Than or Equal To</li>
-        <li><span class="unicode" role="math">&#x2265</span><span class="text">≥</span><span class="name">Greater-Than or Equal To</li>
-        <li><span class="unicode" role="math">&#x2266</span><span class="text">≦</span><span class="name">Less-Than Over Equal To</li>
-        <li><span class="unicode" role="math">&#x2267</span><span class="text">≧</span><span class="name">Greater-Than Over Equal To</li>
-        <li><span class="unicode" role="math">&#x2268</span><span class="text">≨</span><span class="name">Less-Than But Not Equal To</li>
-        <li><span class="unicode" role="math">&#x2269</span><span class="text">≩</span><span class="name">Greater-Than But Not Equal To</li>
-        <li><span class="unicode" role="math">&#x226A</span><span class="text">≪</span><span class="name">Much Less-Than</li>
-        <li><span class="unicode" role="math">&#x226B</span><span class="text">≫</span><span class="name">Much Greater-Than</li>
-        <li><span class="unicode" role="math">&#x226C</span><span class="text">≬</span><span class="name">Between</li>
-        <li><span class="unicode" role="math">&#x226D</span><span class="text">≭</span><span class="name">Not Equivalent To</li>
-        <li><span class="unicode" role="math">&#x226E</span><span class="text">≮</span><span class="name">Not Less-Than</li>
-        <li><span class="unicode" role="math">&#x226F</span><span class="text">≯</span><span class="name">Not Greater-Than</li>
-        <li><span class="unicode" role="math">&#x2270</span><span class="text">≰</span><span class="name">Neither Less-Than Nor Equal To</li>
-        <li><span class="unicode" role="math">&#x2271</span><span class="text">≱</span><span class="name">Neither Greater-Than Nor Equal To</li>
-        <li><span class="unicode" role="math">&#x2272</span><span class="text">≲</span><span class="name">Less-Than or Equivalent To</li>
-        <li><span class="unicode" role="math">&#x2273</span><span class="text">≳</span><span class="name">Greater-Than or Equivalent To</li>
-        <li><span class="unicode" role="math">&#x2274</span><span class="text">≴</span><span class="name">Neither Less-Than Nor Equivalent To</li>
-        <li><span class="unicode" role="math">&#x2275</span><span class="text">≵</span><span class="name">Neither Greater-Than Nor Equivalent To</li>
-        <li><span class="unicode" role="math">&#x2276</span><span class="text">≶</span><span class="name">Less-Than or Greater-Than</li>
-        <li><span class="unicode" role="math">&#x2277</span><span class="text">≷</span><span class="name">Greater-Than or Less-Than</li>
-        <li><span class="unicode" role="math">&#x2278</span><span class="text">≸</span><span class="name">Neither Less-Than Nor Greater-Than</li>
-        <li><span class="unicode" role="math">&#x2279</span><span class="text">≹</span><span class="name">Neither Greater-Than Nor Less-Than</li>
-        <li><span class="unicode" role="math">&#x227A</span><span class="text">≺</span><span class="name">Precedes</li>
-        <li><span class="unicode" role="math">&#x227B</span><span class="text">≻</span><span class="name">Succeeds</li>
-        <li><span class="unicode" role="math">&#x227C</span><span class="text">≼</span><span class="name">Precedes or Equal To</li>
-        <li><span class="unicode" role="math">&#x227D</span><span class="text">≽</span><span class="name">Succeeds or Equal To</li>
-        <li><span class="unicode" role="math">&#x227E</span><span class="text">≾</span><span class="name">Precedes or Equivalent To</li>
-        <li><span class="unicode" role="math">&#x227F</span><span class="text">≿</span><span class="name">Succeeds or Equivalent To</li>
-        <li><span class="unicode" role="math">&#x2280</span><span class="text">⊀</span><span class="name">Does Not Precede</li>
-        <li><span class="unicode" role="math">&#x2281</span><span class="text">⊁</span><span class="name">Does Not Succeed</li>
-        <li><span class="unicode" role="math">&#x2282</span><span class="text">⊂</span><span class="name">Subset Of</li>
-        <li><span class="unicode" role="math">&#x2283</span><span class="text">⊃</span><span class="name">Superset Of</li>
-        <li><span class="unicode" role="math">&#x2284</span><span class="text">⊄</span><span class="name">Not A Subset Of</li>
-        <li><span class="unicode" role="math">&#x2285</span><span class="text">⊅</span><span class="name">Not A Superset Of</li>
-        <li><span class="unicode" role="math">&#x2286</span><span class="text">⊆</span><span class="name">Subset of or Equal To</li>
-        <li><span class="unicode" role="math">&#x2287</span><span class="text">⊇</span><span class="name">Superset of or Equal To</li>
-        <li><span class="unicode" role="math">&#x2288</span><span class="text">⊈</span><span class="name">Neither A Subset of Nor Equal To</li>
-        <li><span class="unicode" role="math">&#x2289</span><span class="text">⊉</span><span class="name">Neither A Superset of Nor Equal To</li>
-        <li><span class="unicode" role="math">&#x228A</span><span class="text">⊊</span><span class="name">Subset of with Not Equal To</li>
-        <li><span class="unicode" role="math">&#x228B</span><span class="text">⊋</span><span class="name">Superset of with Not Equal To</li>
-        <li><span class="unicode" role="math">&#x228C</span><span class="text">⊌</span><span class="name">Multiset</li>
-        <li><span class="unicode" role="math">&#x228D</span><span class="text">⊍</span><span class="name">Multiset Multiplication</li>
-        <li><span class="unicode" role="math">&#x228E</span><span class="text">⊎</span><span class="name">Multiset Union</li>
-        <li><span class="unicode" role="math">&#x228F</span><span class="text">⊏</span><span class="name">Square Image Of</li>
-        <li><span class="unicode" role="math">&#x2290</span><span class="text">⊐</span><span class="name">Square Original Of</li>
-        <li><span class="unicode" role="math">&#x2291</span><span class="text">⊑</span><span class="name">Square Image of or Equal To</li>
-        <li><span class="unicode" role="math">&#x2292</span><span class="text">⊒</span><span class="name">Square Original of or Equal To</li>
-        <li><span class="unicode" role="math">&#x2293</span><span class="text">⊓</span><span class="name">Square Cap</li>
-        <li><span class="unicode" role="math">&#x2294</span><span class="text">⊔</span><span class="name">Square Cup</li>
-        <li><span class="unicode" role="math">&#x2295</span><span class="text">⊕</span><span class="name">Circled Plus</li>
-        <li><span class="unicode" role="math">&#x2296</span><span class="text">⊖</span><span class="name">Circled Minus</li>
-        <li><span class="unicode" role="math">&#x2297</span><span class="text">⊗</span><span class="name">Circled Times</li>
-        <li><span class="unicode" role="math">&#x2298</span><span class="text">⊘</span><span class="name">Circled Division Slash</li>
-        <li><span class="unicode" role="math">&#x2299</span><span class="text">⊙</span><span class="name">Circled Dot Operator</li>
-        <li><span class="unicode" role="math">&#x229A</span><span class="text">⊚</span><span class="name">Circled Ring Operator</li>
-        <li><span class="unicode" role="math">&#x229B</span><span class="text">⊛</span><span class="name">Circled Asterisk Operator</li>
-        <li><span class="unicode" role="math">&#x229C</span><span class="text">⊜</span><span class="name">Circled Equals</li>
-        <li><span class="unicode" role="math">&#x229D</span><span class="text">⊝</span><span class="name">Circled Dash</li>
-        <li><span class="unicode" role="math">&#x229E</span><span class="text">⊞</span><span class="name">Squared Plus</li>
-        <li><span class="unicode" role="math">&#x229F</span><span class="text">⊟</span><span class="name">Squared Minus</li>
-        <li><span class="unicode" role="math">&#x22A0</span><span class="text">⊠</span><span class="name">Squared Times</li>
-        <li><span class="unicode" role="math">&#x22A1</span><span class="text">⊡</span><span class="name">Squared Dot Operator</li>
-        <li><span class="unicode" role="math">&#x22A2</span><span class="text">⊢</span><span class="name">Right Tack</li>
-        <li><span class="unicode" role="math">&#x22A3</span><span class="text">⊣</span><span class="name">Left Tack</li>
-        <li><span class="unicode" role="math">&#x22A4</span><span class="text">⊤</span><span class="name">Down Tack</li>
-        <li><span class="unicode" role="math">&#x22A5</span><span class="text">⊥</span><span class="name">Up Tack</li>
-        <li><span class="unicode" role="math">&#x22A6</span><span class="text">⊦</span><span class="name">Assertion</li>
-        <li><span class="unicode" role="math">&#x22A7</span><span class="text">⊧</span><span class="name">Models</li>
-        <li><span class="unicode" role="math">&#x22A8</span><span class="text">⊨</span><span class="name">True</li>
-        <li><span class="unicode" role="math">&#x22A9</span><span class="text">⊩</span><span class="name">Forces</li>
-        <li><span class="unicode" role="math">&#x22AA</span><span class="text">⊪</span><span class="name">Triple Vertical Bar Right Turnstile</li>
-        <li><span class="unicode" role="math">&#x22AB</span><span class="text">⊫</span><span class="name">Double Vertical Bar Double Right Turnstile</li>
-        <li><span class="unicode" role="math">&#x22AC</span><span class="text">⊬</span><span class="name">Does Not Prove</li>
-        <li><span class="unicode" role="math">&#x22AD</span><span class="text">⊭</span><span class="name">Not True</li>
-        <li><span class="unicode" role="math">&#x22AE</span><span class="text">⊮</span><span class="name">Does Not Force</li>
-        <li><span class="unicode" role="math">&#x22AF</span><span class="text">⊯</span><span class="name">Negated Double Vertical Bar Double Right Turnstile</li>
-        <li><span class="unicode" role="math">&#x22B0</span><span class="text">⊰</span><span class="name">Precedes Under Relation</li>
-        <li><span class="unicode" role="math">&#x22B1</span><span class="text">⊱</span><span class="name">Succeeds Under Relation</li>
-        <li><span class="unicode" role="math">&#x22B2</span><span class="text">⊲</span><span class="name">Normal Subgroup Of</li>
-        <li><span class="unicode" role="math">&#x22B3</span><span class="text">⊳</span><span class="name">Contains as Normal Subgroup</li>
-        <li><span class="unicode" role="math">&#x22B4</span><span class="text">⊴</span><span class="name">Normal Subgroup of or Equal To</li>
-        <li><span class="unicode" role="math">&#x22B5</span><span class="text">⊵</span><span class="name">Contains as Normal Subgroup or Equal To</li>
-        <li><span class="unicode" role="math">&#x22B6</span><span class="text">⊶</span><span class="name">Original Of</li>
-        <li><span class="unicode" role="math">&#x22B7</span><span class="text">⊷</span><span class="name">Image Of</li>
-        <li><span class="unicode" role="math">&#x22B8</span><span class="text">⊸</span><span class="name">Multimap</li>
-        <li><span class="unicode" role="math">&#x22B9</span><span class="text">⊹</span><span class="name">Hermitian Conjugate Matrix</li>
-        <li><span class="unicode" role="math">&#x22BA</span><span class="text">⊺</span><span class="name">Intercalate</li>
-        <li><span class="unicode" role="math">&#x22BB</span><span class="text">⊻</span><span class="name">Xor</li>
-        <li><span class="unicode" role="math">&#x22BC</span><span class="text">⊼</span><span class="name">Nand</li>
-        <li><span class="unicode" role="math">&#x22BD</span><span class="text">⊽</span><span class="name">Nor</li>
-        <li><span class="unicode" role="math">&#x22BE</span><span class="text">⊾</span><span class="name">Right Angle with Arc</li>
-        <li><span class="unicode" role="math">&#x22BF</span><span class="text">⊿</span><span class="name">Right Triangle</li>
-        <li><span class="unicode" role="math">&#x22C0</span><span class="text">⋀</span><span class="name">N-Ary Logical And</li>
-        <li><span class="unicode" role="math">&#x22C1</span><span class="text">⋁</span><span class="name">N-Ary Logical Or</li>
-        <li><span class="unicode" role="math">&#x22C2</span><span class="text">⋂</span><span class="name">N-Ary Intersection</li>
-        <li><span class="unicode" role="math">&#x22C3</span><span class="text">⋃</span><span class="name">N-Ary Union</li>
-        <li><span class="unicode" role="math">&#x22C4</span><span class="text">⋄</span><span class="name">Diamond Operator</li>
-        <li><span class="unicode" role="math">&#x22C5</span><span class="text">⋅</span><span class="name">Dot Operator</li>
-        <li><span class="unicode" role="math">&#x22C6</span><span class="text">⋆</span><span class="name">Star Operator</li>
-        <li><span class="unicode" role="math">&#x22C7</span><span class="text">⋇</span><span class="name">Division Times</li>
-        <li><span class="unicode" role="math">&#x22C8</span><span class="text">⋈</span><span class="name">Bowtie</li>
-        <li><span class="unicode" role="math">&#x22C9</span><span class="text">⋉</span><span class="name">Left Normal Factor Semidirect Product</li>
-        <li><span class="unicode" role="math">&#x22CA</span><span class="text">⋊</span><span class="name">Right Normal Factor Semidirect Product</li>
-        <li><span class="unicode" role="math">&#x22CB</span><span class="text">⋋</span><span class="name">Left Semidirect Product</li>
-        <li><span class="unicode" role="math">&#x22CC</span><span class="text">⋌</span><span class="name">Right Semidirect Product</li>
-        <li><span class="unicode" role="math">&#x22CD</span><span class="text">⋍</span><span class="name">Reversed Tilde Equals</li>
-        <li><span class="unicode" role="math">&#x22CE</span><span class="text">⋎</span><span class="name">Curly Logical Or</li>
-        <li><span class="unicode" role="math">&#x22CF</span><span class="text">⋏</span><span class="name">Curly Logical And</li>
-        <li><span class="unicode" role="math">&#x22D0</span><span class="text">⋐</span><span class="name">Double Subset</li>
-        <li><span class="unicode" role="math">&#x22D1</span><span class="text">⋑</span><span class="name">Double Superset</li>
-        <li><span class="unicode" role="math">&#x22D2</span><span class="text">⋒</span><span class="name">Double Intersection</li>
-        <li><span class="unicode" role="math">&#x22D3</span><span class="text">⋓</span><span class="name">Double Union</li>
-        <li><span class="unicode" role="math">&#x22D4</span><span class="text">⋔</span><span class="name">Pitchfork</li>
-        <li><span class="unicode" role="math">&#x22D5</span><span class="text">⋕</span><span class="name">Equal and Parallel To</li>
-        <li><span class="unicode" role="math">&#x22D6</span><span class="text">⋖</span><span class="name">Less-Than with Dot</li>
-        <li><span class="unicode" role="math">&#x22D7</span><span class="text">⋗</span><span class="name">Greater-Than with Dot</li>
-        <li><span class="unicode" role="math">&#x22D8</span><span class="text">⋘</span><span class="name">Very Much Less-Than</li>
-        <li><span class="unicode" role="math">&#x22D9</span><span class="text">⋙</span><span class="name">Very Much Greater-Than</li>
-        <li><span class="unicode" role="math">&#x22DA</span><span class="text">⋚</span><span class="name">Less-Than Equal to or Greater-Than</li>
-        <li><span class="unicode" role="math">&#x22DB</span><span class="text">⋛</span><span class="name">Greater-Than Equal to or Less-Than</li>
-        <li><span class="unicode" role="math">&#x22DC</span><span class="text">⋜</span><span class="name">Equal to or Less-Than</li>
-        <li><span class="unicode" role="math">&#x22DD</span><span class="text">⋝</span><span class="name">Equal to or Greater-Than</li>
-        <li><span class="unicode" role="math">&#x22DE</span><span class="text">⋞</span><span class="name">Equal to or Precedes</li>
-        <li><span class="unicode" role="math">&#x22DF</span><span class="text">⋟</span><span class="name">Equal to or Succeeds</li>
-        <li><span class="unicode" role="math">&#x22E0</span><span class="text">⋠</span><span class="name">Does Not Precede or Equal</li>
-        <li><span class="unicode" role="math">&#x22E1</span><span class="text">⋡</span><span class="name">Does Not Succeed or Equal</li>
-        <li><span class="unicode" role="math">&#x22E2</span><span class="text">⋢</span><span class="name">Not Square Image of or Equal To</li>
-        <li><span class="unicode" role="math">&#x22E3</span><span class="text">⋣</span><span class="name">Not Square Original of or Equal To</li>
-        <li><span class="unicode" role="math">&#x22E4</span><span class="text">⋤</span><span class="name">Square Image of or Not Equal To</li>
-        <li><span class="unicode" role="math">&#x22E5</span><span class="text">⋥</span><span class="name">Square Original of or Not Equal To</li>
-        <li><span class="unicode" role="math">&#x22E6</span><span class="text">⋦</span><span class="name">Less-Than But Not Equivalent To</li>
-        <li><span class="unicode" role="math">&#x22E7</span><span class="text">⋧</span><span class="name">Greater-Than But Not Equivalent To</li>
-        <li><span class="unicode" role="math">&#x22E8</span><span class="text">⋨</span><span class="name">Precedes But Not Equivalent To</li>
-        <li><span class="unicode" role="math">&#x22E9</span><span class="text">⋩</span><span class="name">Succeeds But Not Equivalent To</li>
-        <li><span class="unicode" role="math">&#x22EA</span><span class="text">⋪</span><span class="name">Not Normal Subgroup Of</li>
-        <li><span class="unicode" role="math">&#x22EB</span><span class="text">⋫</span><span class="name">Does Not Contain as Normal Subgroup</li>
-        <li><span class="unicode" role="math">&#x22EC</span><span class="text">⋬</span><span class="name">Not Normal Subgroup of or Equal To</li>
-        <li><span class="unicode" role="math">&#x22ED</span><span class="text">⋭</span><span class="name">Does Not Contain as Normal Subgroup or Equal</li>
-        <li><span class="unicode" role="math">&#x22EE</span><span class="text">⋮</span><span class="name">Vertical Ellipsis</li>
-        <li><span class="unicode" role="math">&#x22EF</span><span class="text">⋯</span><span class="name">Midline Horizontal Ellipsis</li>
-        <li><span class="unicode" role="math">&#x22F0</span><span class="text">⋰</span><span class="name">Up Right Diagonal Ellipsis</li>
-        <li><span class="unicode" role="math">&#x22F1</span><span class="text">⋱</span><span class="name">Down Right Diagonal Ellipsis</li>
-        <li><span class="unicode" role="math">&#x22F2</span><span class="text">⋲</span><span class="name">Element of with Long Horizontal Stroke</li>
-        <li><span class="unicode" role="math">&#x22F3</span><span class="text">⋳</span><span class="name">Element of with Vertical Bar at End of Horizontal Stroke</li>
-        <li><span class="unicode" role="math">&#x22F4</span><span class="text">⋴</span><span class="name">Small Element of with Vertical Bar at End of Horizontal Stroke</li>
-        <li><span class="unicode" role="math">&#x22F5</span><span class="text">⋵</span><span class="name">Element of with Dot Above</li>
-        <li><span class="unicode" role="math">&#x22F6</span><span class="text">⋶</span><span class="name">Element of with Overbar</li>
-        <li><span class="unicode" role="math">&#x22F7</span><span class="text">⋷</span><span class="name">Small Element of with Overbar</li>
-        <li><span class="unicode" role="math">&#x22F8</span><span class="text">⋸</span><span class="name">Element of with Underbar</li>
-        <li><span class="unicode" role="math">&#x22F9</span><span class="text">⋹</span><span class="name">Element of with Two Horizontal Strokes</li>
-        <li><span class="unicode" role="math">&#x22FA</span><span class="text">⋺</span><span class="name">Contains with Long Horizontal Stroke</li>
-        <li><span class="unicode" role="math">&#x22FB</span><span class="text">⋻</span><span class="name">Contains with Vertical Bar at End of Horizontal Stroke</li>
-        <li><span class="unicode" role="math">&#x22FC</span><span class="text">⋼</span><span class="name">Small Contains with Vertical Bar at End of Horizontal Stroke</li>
-        <li><span class="unicode" role="math">&#x22FD</span><span class="text">⋽</span><span class="name">Contains with Overbar</li>
-        <li><span class="unicode" role="math">&#x22FE</span><span class="text">⋾</span><span class="name">Small Contains with Overbar</li>
-        <li><span class="unicode" role="math">&#x22FF</span><span class="text">⋿</span><span class="name">Z Notation Bag Membership</li>
-        <li><span class="unicode" role="math">&#x2320</span><span class="text">⌠</span><span class="name">Top Half Integral</li>
-        <li><span class="unicode" role="math">&#x2321</span><span class="text">⌡</span><span class="name">Bottom Half Integral</li>
-        <li><span class="unicode" role="math">&#x237C</span><span class="text">⍼</span><span class="name">Right Angle with Downwards Zigzag Arrow</li>
-        <li><span class="unicode" role="math">&#x239B</span><span class="text">⎛</span><span class="name">Left Parenthesis Upper Hook</li>
-        <li><span class="unicode" role="math">&#x239C</span><span class="text">⎜</span><span class="name">Left Parenthesis Extension</li>
-        <li><span class="unicode" role="math">&#x239D</span><span class="text">⎝</span><span class="name">Left Parenthesis Lower Hook</li>
-        <li><span class="unicode" role="math">&#x239E</span><span class="text">⎞</span><span class="name">Right Parenthesis Upper Hook</li>
-        <li><span class="unicode" role="math">&#x239F</span><span class="text">⎟</span><span class="name">Right Parenthesis Extension</li>
-        <li><span class="unicode" role="math">&#x23A0</span><span class="text">⎠</span><span class="name">Right Parenthesis Lower Hook</li>
-        <li><span class="unicode" role="math">&#x23A1</span><span class="text">⎡</span><span class="name">Left Square Bracket Upper Corner</li>
-        <li><span class="unicode" role="math">&#x23A2</span><span class="text">⎢</span><span class="name">Left Square Bracket Extension</li>
-        <li><span class="unicode" role="math">&#x23A3</span><span class="text">⎣</span><span class="name">Left Square Bracket Lower Corner</li>
-        <li><span class="unicode" role="math">&#x23A4</span><span class="text">⎤</span><span class="name">Right Square Bracket Upper Corner</li>
-        <li><span class="unicode" role="math">&#x23A5</span><span class="text">⎥</span><span class="name">Right Square Bracket Extension</li>
-        <li><span class="unicode" role="math">&#x23A6</span><span class="text">⎦</span><span class="name">Right Square Bracket Lower Corner</li>
-        <li><span class="unicode" role="math">&#x23A7</span><span class="text">⎧</span><span class="name">Left Curly Bracket Upper Hook</li>
-        <li><span class="unicode" role="math">&#x23A8</span><span class="text">⎨</span><span class="name">Left Curly Bracket Middle Piece</li>
-        <li><span class="unicode" role="math">&#x23A9</span><span class="text">⎩</span><span class="name">Left Curly Bracket Lower Hook</li>
-        <li><span class="unicode" role="math">&#x23AA</span><span class="text">⎪</span><span class="name">Curly Bracket Extension</li>
-        <li><span class="unicode" role="math">&#x23AB</span><span class="text">⎫</span><span class="name">Right Curly Bracket Upper Hook</li>
-        <li><span class="unicode" role="math">&#x23AC</span><span class="text">⎬</span><span class="name">Right Curly Bracket Middle Piece</li>
-        <li><span class="unicode" role="math">&#x23AD</span><span class="text">⎭</span><span class="name">Right Curly Bracket Lower Hook</li>
-        <li><span class="unicode" role="math">&#x23AE</span><span class="text">⎮</span><span class="name">Integral Extension</li>
-        <li><span class="unicode" role="math">&#x23AF</span><span class="text">⎯</span><span class="name">Horizontal Line Extension</li>
-        <li><span class="unicode" role="math">&#x23B0</span><span class="text">⎰</span><span class="name">Upper Left or Lower Right Curly Bracket Section</li>
-        <li><span class="unicode" role="math">&#x23B1</span><span class="text">⎱</span><span class="name">Upper Right or Lower Left Curly Bracket Section</li>
-        <li><span class="unicode" role="math">&#x23B2</span><span class="text">⎲</span><span class="name">Summation Top</li>
-        <li><span class="unicode" role="math">&#x23B3</span><span class="text">⎳</span><span class="name">Summation Bottom</li>
-        <li><span class="unicode" role="math">&#x23DC</span><span class="text">⏜</span><span class="name">Top Parenthesis</li>
-        <li><span class="unicode" role="math">&#x23DD</span><span class="text">⏝</span><span class="name">Bottom Parenthesis</li>
-        <li><span class="unicode" role="math">&#x23DE</span><span class="text">⏞</span><span class="name">Top Curly Bracket</li>
-        <li><span class="unicode" role="math">&#x23DF</span><span class="text">⏟</span><span class="name">Bottom Curly Bracket</li>
-        <li><span class="unicode" role="math">&#x23E0</span><span class="text">⏠</span><span class="name">Top Tortoise Shell Bracket</li>
-        <li><span class="unicode" role="math">&#x23E1</span><span class="text">⏡</span><span class="name">Bottom Tortoise Shell Bracket</li>
-        <li><span class="unicode" role="math">&#x25B7</span><span class="text">▷</span><span class="name">White Right-Pointing Triangle</li>
-        <li><span class="unicode" role="math">&#x25C1</span><span class="text">◁</span><span class="name">White Left-Pointing Triangle</li>
-        <li><span class="unicode" role="math">&#x25F8</span><span class="text">◸</span><span class="name">Upper Left Triangle</li>
-        <li><span class="unicode" role="math">&#x25F9</span><span class="text">◹</span><span class="name">Upper Right Triangle</li>
-        <li><span class="unicode" role="math">&#x25FA</span><span class="text">◺</span><span class="name">Lower Left Triangle</li>
-        <li><span class="unicode" role="math">&#x25FB</span><span class="text">◻</span><span class="name">White Medium Square</li>
-        <li><span class="unicode" role="math">&#x25FC</span><span class="text">◼</span><span class="name">Black Medium Square</li>
-        <li><span class="unicode" role="math">&#x25FD</span><span class="text">◽</span><span class="name">White Medium Small Square</li>
-        <li><span class="unicode" role="math">&#x25FE</span><span class="text">◾</span><span class="name">Black Medium Small Square</li>
-        <li><span class="unicode" role="math">&#x25FF</span><span class="text">◿</span><span class="name">Lower Right Triangle</li>
-        <li><span class="unicode" role="math">&#x266F</span><span class="text">♯</span><span class="name">Music Sharp Sign</li>
-        <li><span class="unicode" role="math">&#x27C0</span><span class="text">⟀</span><span class="name">Three Dimensional Angle</li>
-        <li><span class="unicode" role="math">&#x27C1</span><span class="text">⟁</span><span class="name">White Triangle Containing Small White Triangle</li>
-        <li><span class="unicode" role="math">&#x27C2</span><span class="text">⟂</span><span class="name">Perpendicular</li>
-        <li><span class="unicode" role="math">&#x27C3</span><span class="text">⟃</span><span class="name">Open Subset</li>
-        <li><span class="unicode" role="math">&#x27C4</span><span class="text">⟄</span><span class="name">Open Superset</li>
-        <li><span class="unicode" role="math">&#x27C7</span><span class="text">⟇</span><span class="name">or with Dot Inside</li>
-        <li><span class="unicode" role="math">&#x27C8</span><span class="text">⟈</span><span class="name">Reverse Solidus Preceding Subset</li>
-        <li><span class="unicode" role="math">&#x27C9</span><span class="text">⟉</span><span class="name">Superset Preceding Solidus</li>
-        <li><span class="unicode" role="math">&#x27CA</span><span class="text">⟊</span><span class="name">Vertical Bar with Horizontal Stroke</li>
-        <li><span class="unicode" role="math">&#x27CB</span><span class="text">⟋</span><span class="name">Mathematical Rising Diagonal</li>
-        <li><span class="unicode" role="math">&#x27CC</span><span class="text">⟌</span><span class="name">Long Division</li>
-        <li><span class="unicode" role="math">&#x27CD</span><span class="text">⟍</span><span class="name">Mathematical Falling Diagonal</li>
-        <li><span class="unicode" role="math">&#x27CE</span><span class="text">⟎</span><span class="name">Squared Logical And</li>
-        <li><span class="unicode" role="math">&#x27CF</span><span class="text">⟏</span><span class="name">Squared Logical Or</li>
-        <li><span class="unicode" role="math">&#x27D0</span><span class="text">⟐</span><span class="name">White Diamond with Centred Dot</li>
-        <li><span class="unicode" role="math">&#x27D1</span><span class="text">⟑</span><span class="name">and with Dot</li>
-        <li><span class="unicode" role="math">&#x27D2</span><span class="text">⟒</span><span class="name">Element of Opening Upwards</li>
-        <li><span class="unicode" role="math">&#x27D3</span><span class="text">⟓</span><span class="name">Lower Right Corner with Dot</li>
-        <li><span class="unicode" role="math">&#x27D4</span><span class="text">⟔</span><span class="name">Upper Left Corner with Dot</li>
-        <li><span class="unicode" role="math">&#x27D5</span><span class="text">⟕</span><span class="name">Left Outer Join</li>
-        <li><span class="unicode" role="math">&#x27D6</span><span class="text">⟖</span><span class="name">Right Outer Join</li>
-        <li><span class="unicode" role="math">&#x27D7</span><span class="text">⟗</span><span class="name">Full Outer Join</li>
-        <li><span class="unicode" role="math">&#x27D8</span><span class="text">⟘</span><span class="name">Large Up Tack</li>
-        <li><span class="unicode" role="math">&#x27D9</span><span class="text">⟙</span><span class="name">Large Down Tack</li>
-        <li><span class="unicode" role="math">&#x27DA</span><span class="text">⟚</span><span class="name">Left and Right Double Turnstile</li>
-        <li><span class="unicode" role="math">&#x27DB</span><span class="text">⟛</span><span class="name">Left and Right Tack</li>
-        <li><span class="unicode" role="math">&#x27DC</span><span class="text">⟜</span><span class="name">Left Multimap</li>
-        <li><span class="unicode" role="math">&#x27DD</span><span class="text">⟝</span><span class="name">Long Right Tack</li>
-        <li><span class="unicode" role="math">&#x27DE</span><span class="text">⟞</span><span class="name">Long Left Tack</li>
-        <li><span class="unicode" role="math">&#x27DF</span><span class="text">⟟</span><span class="name">Up Tack with Circle Above</li>
-        <li><span class="unicode" role="math">&#x27E0</span><span class="text">⟠</span><span class="name">Lozenge Divided By Horizontal Rule</li>
-        <li><span class="unicode" role="math">&#x27E1</span><span class="text">⟡</span><span class="name">White Concave-Sided Diamond</li>
-        <li><span class="unicode" role="math">&#x27E2</span><span class="text">⟢</span><span class="name">White Concave-Sided Diamond with Leftwards Tick</li>
-        <li><span class="unicode" role="math">&#x27E3</span><span class="text">⟣</span><span class="name">White Concave-Sided Diamond with Rightwards Tick</li>
-        <li><span class="unicode" role="math">&#x27E4</span><span class="text">⟤</span><span class="name">White Square with Leftwards Tick</li>
-        <li><span class="unicode" role="math">&#x27E5</span><span class="text">⟥</span><span class="name">White Square with Rightwards Tick</li>
-        <li><span class="unicode" role="math">&#x27F0</span><span class="text">⟰</span><span class="name">Upwards Quadruple Arrow</li>
-        <li><span class="unicode" role="math">&#x27F1</span><span class="text">⟱</span><span class="name">Downwards Quadruple Arrow</li>
-        <li><span class="unicode" role="math">&#x27F2</span><span class="text">⟲</span><span class="name">Anticlockwise Gapped Circle Arrow</li>
-        <li><span class="unicode" role="math">&#x27F3</span><span class="text">⟳</span><span class="name">Clockwise Gapped Circle Arrow</li>
-        <li><span class="unicode" role="math">&#x27F4</span><span class="text">⟴</span><span class="name">Right Arrow with Circled Plus</li>
-        <li><span class="unicode" role="math">&#x27F5</span><span class="text">⟵</span><span class="name">Long Leftwards Arrow</li>
-        <li><span class="unicode" role="math">&#x27F6</span><span class="text">⟶</span><span class="name">Long Rightwards Arrow</li>
-        <li><span class="unicode" role="math">&#x27F7</span><span class="text">⟷</span><span class="name">Long Left Right Arrow</li>
-        <li><span class="unicode" role="math">&#x27F8</span><span class="text">⟸</span><span class="name">Long Leftwards Double Arrow</li>
-        <li><span class="unicode" role="math">&#x27F9</span><span class="text">⟹</span><span class="name">Long Rightwards Double Arrow</li>
-        <li><span class="unicode" role="math">&#x27FA</span><span class="text">⟺</span><span class="name">Long Left Right Double Arrow</li>
-        <li><span class="unicode" role="math">&#x27FB</span><span class="text">⟻</span><span class="name">Long Leftwards Arrow from Bar</li>
-        <li><span class="unicode" role="math">&#x27FC</span><span class="text">⟼</span><span class="name">Long Rightwards Arrow from Bar</li>
-        <li><span class="unicode" role="math">&#x27FD</span><span class="text">⟽</span><span class="name">Long Leftwards Double Arrow from Bar</li>
-        <li><span class="unicode" role="math">&#x27FE</span><span class="text">⟾</span><span class="name">Long Rightwards Double Arrow from Bar</li>
-        <li><span class="unicode" role="math">&#x27FF</span><span class="text">⟿</span><span class="name">Long Rightwards Squiggle Arrow</li>
-        <li><span class="unicode" role="math">&#x2900</span><span class="text">⤀</span><span class="name">Rightwards Two-Headed Arrow with Vertical Stroke</li>
-        <li><span class="unicode" role="math">&#x2901</span><span class="text">⤁</span><span class="name">Rightwards Two-Headed Arrow with Double Vertical Stroke</li>
-        <li><span class="unicode" role="math">&#x2902</span><span class="text">⤂</span><span class="name">Leftwards Double Arrow with Vertical Stroke</li>
-        <li><span class="unicode" role="math">&#x2903</span><span class="text">⤃</span><span class="name">Rightwards Double Arrow with Vertical Stroke</li>
-        <li><span class="unicode" role="math">&#x2904</span><span class="text">⤄</span><span class="name">Left Right Double Arrow with Vertical Stroke</li>
-        <li><span class="unicode" role="math">&#x2905</span><span class="text">⤅</span><span class="name">Rightwards Two-Headed Arrow from Bar</li>
-        <li><span class="unicode" role="math">&#x2906</span><span class="text">⤆</span><span class="name">Leftwards Double Arrow from Bar</li>
-        <li><span class="unicode" role="math">&#x2907</span><span class="text">⤇</span><span class="name">Rightwards Double Arrow from Bar</li>
-        <li><span class="unicode" role="math">&#x2908</span><span class="text">⤈</span><span class="name">Downwards Arrow with Horizontal Stroke</li>
-        <li><span class="unicode" role="math">&#x2909</span><span class="text">⤉</span><span class="name">Upwards Arrow with Horizontal Stroke</li>
-        <li><span class="unicode" role="math">&#x290A</span><span class="text">⤊</span><span class="name">Upwards Triple Arrow</li>
-        <li><span class="unicode" role="math">&#x290B</span><span class="text">⤋</span><span class="name">Downwards Triple Arrow</li>
-        <li><span class="unicode" role="math">&#x290C</span><span class="text">⤌</span><span class="name">Leftwards Double Dash Arrow</li>
-        <li><span class="unicode" role="math">&#x290D</span><span class="text">⤍</span><span class="name">Rightwards Double Dash Arrow</li>
-        <li><span class="unicode" role="math">&#x290E</span><span class="text">⤎</span><span class="name">Leftwards Triple Dash Arrow</li>
-        <li><span class="unicode" role="math">&#x290F</span><span class="text">⤏</span><span class="name">Rightwards Triple Dash Arrow</li>
-        <li><span class="unicode" role="math">&#x2910</span><span class="text">⤐</span><span class="name">Rightwards Two-Headed Triple Dash Arrow</li>
-        <li><span class="unicode" role="math">&#x2911</span><span class="text">⤑</span><span class="name">Rightwards Arrow with Dotted Stem</li>
-        <li><span class="unicode" role="math">&#x2912</span><span class="text">⤒</span><span class="name">Upwards Arrow to Bar</li>
-        <li><span class="unicode" role="math">&#x2913</span><span class="text">⤓</span><span class="name">Downwards Arrow to Bar</li>
-        <li><span class="unicode" role="math">&#x2914</span><span class="text">⤔</span><span class="name">Rightwards Arrow with Tail with Vertical Stroke</li>
-        <li><span class="unicode" role="math">&#x2915</span><span class="text">⤕</span><span class="name">Rightwards Arrow with Tail with Double Vertical Stroke</li>
-        <li><span class="unicode" role="math">&#x2916</span><span class="text">⤖</span><span class="name">Rightwards Two-Headed Arrow with Tail</li>
-        <li><span class="unicode" role="math">&#x2917</span><span class="text">⤗</span><span class="name">Rightwards Two-Headed Arrow with Tail with Vertical Stroke</li>
-        <li><span class="unicode" role="math">&#x2918</span><span class="text">⤘</span><span class="name">Rightwards Two-Headed Arrow with Tail with Double Vertical Stroke</li>
-        <li><span class="unicode" role="math">&#x2919</span><span class="text">⤙</span><span class="name">Leftwards Arrow-Tail</li>
-        <li><span class="unicode" role="math">&#x291A</span><span class="text">⤚</span><span class="name">Rightwards Arrow-Tail</li>
-        <li><span class="unicode" role="math">&#x291B</span><span class="text">⤛</span><span class="name">Leftwards Double Arrow-Tail</li>
-        <li><span class="unicode" role="math">&#x291C</span><span class="text">⤜</span><span class="name">Rightwards Double Arrow-Tail</li>
-        <li><span class="unicode" role="math">&#x291D</span><span class="text">⤝</span><span class="name">Leftwards Arrow to Black Diamond</li>
-        <li><span class="unicode" role="math">&#x291E</span><span class="text">⤞</span><span class="name">Rightwards Arrow to Black Diamond</li>
-        <li><span class="unicode" role="math">&#x291F</span><span class="text">⤟</span><span class="name">Leftwards Arrow from Bar to Black Diamond</li>
-        <li><span class="unicode" role="math">&#x2920</span><span class="text">⤠</span><span class="name">Rightwards Arrow from Bar to Black Diamond</li>
-        <li><span class="unicode" role="math">&#x2921</span><span class="text">⤡</span><span class="name">North West and South East Arrow</li>
-        <li><span class="unicode" role="math">&#x2922</span><span class="text">⤢</span><span class="name">North East and South West Arrow</li>
-        <li><span class="unicode" role="math">&#x2923</span><span class="text">⤣</span><span class="name">North West Arrow with Hook</li>
-        <li><span class="unicode" role="math">&#x2924</span><span class="text">⤤</span><span class="name">North East Arrow with Hook</li>
-        <li><span class="unicode" role="math">&#x2925</span><span class="text">⤥</span><span class="name">South East Arrow with Hook</li>
-        <li><span class="unicode" role="math">&#x2926</span><span class="text">⤦</span><span class="name">South West Arrow with Hook</li>
-        <li><span class="unicode" role="math">&#x2927</span><span class="text">⤧</span><span class="name">North West Arrow and North East Arrow</li>
-        <li><span class="unicode" role="math">&#x2928</span><span class="text">⤨</span><span class="name">North East Arrow and South East Arrow</li>
-        <li><span class="unicode" role="math">&#x2929</span><span class="text">⤩</span><span class="name">South East Arrow and South West Arrow</li>
-        <li><span class="unicode" role="math">&#x292A</span><span class="text">⤪</span><span class="name">South West Arrow and North West Arrow</li>
-        <li><span class="unicode" role="math">&#x292B</span><span class="text">⤫</span><span class="name">Rising Diagonal Crossing Falling Diagonal</li>
-        <li><span class="unicode" role="math">&#x292C</span><span class="text">⤬</span><span class="name">Falling Diagonal Crossing Rising Diagonal</li>
-        <li><span class="unicode" role="math">&#x292D</span><span class="text">⤭</span><span class="name">South East Arrow Crossing North East Arrow</li>
-        <li><span class="unicode" role="math">&#x292E</span><span class="text">⤮</span><span class="name">North East Arrow Crossing South East Arrow</li>
-        <li><span class="unicode" role="math">&#x292F</span><span class="text">⤯</span><span class="name">Falling Diagonal Crossing North East Arrow</li>
-        <li><span class="unicode" role="math">&#x2930</span><span class="text">⤰</span><span class="name">Rising Diagonal Crossing South East Arrow</li>
-        <li><span class="unicode" role="math">&#x2931</span><span class="text">⤱</span><span class="name">North East Arrow Crossing North West Arrow</li>
-        <li><span class="unicode" role="math">&#x2932</span><span class="text">⤲</span><span class="name">North West Arrow Crossing North East Arrow</li>
-        <li><span class="unicode" role="math">&#x2933</span><span class="text">⤳</span><span class="name">Wave Arrow Pointing Directly Right</li>
-        <li><span class="unicode" role="math">&#x2934</span><span class="text">⤴</span><span class="name">Arrow Pointing Rightwards Then Curving Upwards</li>
-        <li><span class="unicode" role="math">&#x2935</span><span class="text">⤵</span><span class="name">Arrow Pointing Rightwards Then Curving Downwards</li>
-        <li><span class="unicode" role="math">&#x2936</span><span class="text">⤶</span><span class="name">Arrow Pointing Downwards Then Curving Leftwards</li>
-        <li><span class="unicode" role="math">&#x2937</span><span class="text">⤷</span><span class="name">Arrow Pointing Downwards Then Curving Rightwards</li>
-        <li><span class="unicode" role="math">&#x2938</span><span class="text">⤸</span><span class="name">Right-Side Arc Clockwise Arrow</li>
-        <li><span class="unicode" role="math">&#x2939</span><span class="text">⤹</span><span class="name">Left-Side Arc Anticlockwise Arrow</li>
-        <li><span class="unicode" role="math">&#x293A</span><span class="text">⤺</span><span class="name">Top Arc Anticlockwise Arrow</li>
-        <li><span class="unicode" role="math">&#x293B</span><span class="text">⤻</span><span class="name">Bottom Arc Anticlockwise Arrow</li>
-        <li><span class="unicode" role="math">&#x293C</span><span class="text">⤼</span><span class="name">Top Arc Clockwise Arrow with Minus</li>
-        <li><span class="unicode" role="math">&#x293D</span><span class="text">⤽</span><span class="name">Top Arc Anticlockwise Arrow with Plus</li>
-        <li><span class="unicode" role="math">&#x293E</span><span class="text">⤾</span><span class="name">Lower Right Semicircular Clockwise Arrow</li>
-        <li><span class="unicode" role="math">&#x293F</span><span class="text">⤿</span><span class="name">Lower Left Semicircular Anticlockwise Arrow</li>
-        <li><span class="unicode" role="math">&#x2940</span><span class="text">⥀</span><span class="name">Anticlockwise Closed Circle Arrow</li>
-        <li><span class="unicode" role="math">&#x2941</span><span class="text">⥁</span><span class="name">Clockwise Closed Circle Arrow</li>
-        <li><span class="unicode" role="math">&#x2942</span><span class="text">⥂</span><span class="name">Rightwards Arrow Above Short Leftwards Arrow</li>
-        <li><span class="unicode" role="math">&#x2943</span><span class="text">⥃</span><span class="name">Leftwards Arrow Above Short Rightwards Arrow</li>
-        <li><span class="unicode" role="math">&#x2944</span><span class="text">⥄</span><span class="name">Short Rightwards Arrow Above Leftwards Arrow</li>
-        <li><span class="unicode" role="math">&#x2945</span><span class="text">⥅</span><span class="name">Rightwards Arrow with Plus Below</li>
-        <li><span class="unicode" role="math">&#x2946</span><span class="text">⥆</span><span class="name">Leftwards Arrow with Plus Below</li>
-        <li><span class="unicode" role="math">&#x2947</span><span class="text">⥇</span><span class="name">Rightwards Arrow Through X</li>
-        <li><span class="unicode" role="math">&#x2948</span><span class="text">⥈</span><span class="name">Left Right Arrow Through Small Circle</li>
-        <li><span class="unicode" role="math">&#x2949</span><span class="text">⥉</span><span class="name">Upwards Two-Headed Arrow from Small Circle</li>
-        <li><span class="unicode" role="math">&#x294A</span><span class="text">⥊</span><span class="name">Left Barb Up Right Barb Down Harpoon</li>
-        <li><span class="unicode" role="math">&#x294B</span><span class="text">⥋</span><span class="name">Left Barb Down Right Barb Up Harpoon</li>
-        <li><span class="unicode" role="math">&#x294C</span><span class="text">⥌</span><span class="name">Up Barb Right Down Barb Left Harpoon</li>
-        <li><span class="unicode" role="math">&#x294D</span><span class="text">⥍</span><span class="name">Up Barb Left Down Barb Right Harpoon</li>
-        <li><span class="unicode" role="math">&#x294E</span><span class="text">⥎</span><span class="name">Left Barb Up Right Barb Up Harpoon</li>
-        <li><span class="unicode" role="math">&#x294F</span><span class="text">⥏</span><span class="name">Up Barb Right Down Barb Right Harpoon</li>
-        <li><span class="unicode" role="math">&#x2950</span><span class="text">⥐</span><span class="name">Left Barb Down Right Barb Down Harpoon</li>
-        <li><span class="unicode" role="math">&#x2951</span><span class="text">⥑</span><span class="name">Up Barb Left Down Barb Left Harpoon</li>
-        <li><span class="unicode" role="math">&#x2952</span><span class="text">⥒</span><span class="name">Leftwards Harpoon with Barb Up to Bar</li>
-        <li><span class="unicode" role="math">&#x2953</span><span class="text">⥓</span><span class="name">Rightwards Harpoon with Barb Up to Bar</li>
-        <li><span class="unicode" role="math">&#x2954</span><span class="text">⥔</span><span class="name">Upwards Harpoon with Barb Right to Bar</li>
-        <li><span class="unicode" role="math">&#x2955</span><span class="text">⥕</span><span class="name">Downwards Harpoon with Barb Right to Bar</li>
-        <li><span class="unicode" role="math">&#x2956</span><span class="text">⥖</span><span class="name">Leftwards Harpoon with Barb Down to Bar</li>
-        <li><span class="unicode" role="math">&#x2957</span><span class="text">⥗</span><span class="name">Rightwards Harpoon with Barb Down to Bar</li>
-        <li><span class="unicode" role="math">&#x2958</span><span class="text">⥘</span><span class="name">Upwards Harpoon with Barb Left to Bar</li>
-        <li><span class="unicode" role="math">&#x2959</span><span class="text">⥙</span><span class="name">Downwards Harpoon with Barb Left to Bar</li>
-        <li><span class="unicode" role="math">&#x295A</span><span class="text">⥚</span><span class="name">Leftwards Harpoon with Barb Up from Bar</li>
-        <li><span class="unicode" role="math">&#x295B</span><span class="text">⥛</span><span class="name">Rightwards Harpoon with Barb Up from Bar</li>
-        <li><span class="unicode" role="math">&#x295C</span><span class="text">⥜</span><span class="name">Upwards Harpoon with Barb Right from Bar</li>
-        <li><span class="unicode" role="math">&#x295D</span><span class="text">⥝</span><span class="name">Downwards Harpoon with Barb Right from Bar</li>
-        <li><span class="unicode" role="math">&#x295E</span><span class="text">⥞</span><span class="name">Leftwards Harpoon with Barb Down from Bar</li>
-        <li><span class="unicode" role="math">&#x295F</span><span class="text">⥟</span><span class="name">Rightwards Harpoon with Barb Down from Bar</li>
-        <li><span class="unicode" role="math">&#x2960</span><span class="text">⥠</span><span class="name">Upwards Harpoon with Barb Left from Bar</li>
-        <li><span class="unicode" role="math">&#x2961</span><span class="text">⥡</span><span class="name">Downwards Harpoon with Barb Left from Bar</li>
-        <li><span class="unicode" role="math">&#x2962</span><span class="text">⥢</span><span class="name">Leftwards Harpoon with Barb Up Above Leftwards Harpoon with Barb Down</li>
-        <li><span class="unicode" role="math">&#x2963</span><span class="text">⥣</span><span class="name">Upwards Harpoon with Barb Left Beside Upwards Harpoon with Barb Right</li>
-        <li><span class="unicode" role="math">&#x2964</span><span class="text">⥤</span><span class="name">Rightwards Harpoon with Barb Up Above Rightwards Harpoon with Barb Down</li>
-        <li><span class="unicode" role="math">&#x2965</span><span class="text">⥥</span><span class="name">Downwards Harpoon with Barb Left Beside Downwards Harpoon with Barb Right</li>
-        <li><span class="unicode" role="math">&#x2966</span><span class="text">⥦</span><span class="name">Leftwards Harpoon with Barb Up Above Rightwards Harpoon with Barb Up</li>
-        <li><span class="unicode" role="math">&#x2967</span><span class="text">⥧</span><span class="name">Leftwards Harpoon with Barb Down Above Rightwards Harpoon with Barb Down</li>
-        <li><span class="unicode" role="math">&#x2968</span><span class="text">⥨</span><span class="name">Rightwards Harpoon with Barb Up Above Leftwards Harpoon with Barb Up</li>
-        <li><span class="unicode" role="math">&#x2969</span><span class="text">⥩</span><span class="name">Rightwards Harpoon with Barb Down Above Leftwards Harpoon with Barb Down</li>
-        <li><span class="unicode" role="math">&#x296A</span><span class="text">⥪</span><span class="name">Leftwards Harpoon with Barb Up Above Long Dash</li>
-        <li><span class="unicode" role="math">&#x296B</span><span class="text">⥫</span><span class="name">Leftwards Harpoon with Barb Down Below Long Dash</li>
-        <li><span class="unicode" role="math">&#x296C</span><span class="text">⥬</span><span class="name">Rightwards Harpoon with Barb Up Above Long Dash</li>
-        <li><span class="unicode" role="math">&#x296D</span><span class="text">⥭</span><span class="name">Rightwards Harpoon with Barb Down Below Long Dash</li>
-        <li><span class="unicode" role="math">&#x296E</span><span class="text">⥮</span><span class="name">Upwards Harpoon with Barb Left Beside Downwards Harpoon with Barb Right</li>
-        <li><span class="unicode" role="math">&#x296F</span><span class="text">⥯</span><span class="name">Downwards Harpoon with Barb Left Beside Upwards Harpoon with Barb Right</li>
-        <li><span class="unicode" role="math">&#x2970</span><span class="text">⥰</span><span class="name">Right Double Arrow with Rounded Head</li>
-        <li><span class="unicode" role="math">&#x2971</span><span class="text">⥱</span><span class="name">Equals Sign Above Rightwards Arrow</li>
-        <li><span class="unicode" role="math">&#x2972</span><span class="text">⥲</span><span class="name">Tilde Operator Above Rightwards Arrow</li>
-        <li><span class="unicode" role="math">&#x2973</span><span class="text">⥳</span><span class="name">Leftwards Arrow Above Tilde Operator</li>
-        <li><span class="unicode" role="math">&#x2974</span><span class="text">⥴</span><span class="name">Rightwards Arrow Above Tilde Operator</li>
-        <li><span class="unicode" role="math">&#x2975</span><span class="text">⥵</span><span class="name">Rightwards Arrow Above Almost Equal To</li>
-        <li><span class="unicode" role="math">&#x2976</span><span class="text">⥶</span><span class="name">Less-Than Above Leftwards Arrow</li>
-        <li><span class="unicode" role="math">&#x2977</span><span class="text">⥷</span><span class="name">Leftwards Arrow Through Less-Than</li>
-        <li><span class="unicode" role="math">&#x2978</span><span class="text">⥸</span><span class="name">Greater-Than Above Rightwards Arrow</li>
-        <li><span class="unicode" role="math">&#x2979</span><span class="text">⥹</span><span class="name">Subset Above Rightwards Arrow</li>
-        <li><span class="unicode" role="math">&#x297A</span><span class="text">⥺</span><span class="name">Leftwards Arrow Through Subset</li>
-        <li><span class="unicode" role="math">&#x297B</span><span class="text">⥻</span><span class="name">Superset Above Leftwards Arrow</li>
-        <li><span class="unicode" role="math">&#x297C</span><span class="text">⥼</span><span class="name">Left Fish Tail</li>
-        <li><span class="unicode" role="math">&#x297D</span><span class="text">⥽</span><span class="name">Right Fish Tail</li>
-        <li><span class="unicode" role="math">&#x297E</span><span class="text">⥾</span><span class="name">Up Fish Tail</li>
-        <li><span class="unicode" role="math">&#x297F</span><span class="text">⥿</span><span class="name">Down Fish Tail</li>
-        <li><span class="unicode" role="math">&#x2980</span><span class="text">⦀</span><span class="name">Triple Vertical Bar Delimiter</li>
-        <li><span class="unicode" role="math">&#x2981</span><span class="text">⦁</span><span class="name">Z Notation Spot</li>
-        <li><span class="unicode" role="math">&#x2982</span><span class="text">⦂</span><span class="name">Z Notation Type Colon</li>
-        <li><span class="unicode" role="math">&#x2999</span><span class="text">⦙</span><span class="name">Dotted Fence</li>
-        <li><span class="unicode" role="math">&#x299A</span><span class="text">⦚</span><span class="name">Vertical Zigzag Line</li>
-        <li><span class="unicode" role="math">&#x299B</span><span class="text">⦛</span><span class="name">Measured Angle Opening Left</li>
-        <li><span class="unicode" role="math">&#x299C</span><span class="text">⦜</span><span class="name">Right Angle Variant with Square</li>
-        <li><span class="unicode" role="math">&#x299D</span><span class="text">⦝</span><span class="name">Measured Right Angle with Dot</li>
-        <li><span class="unicode" role="math">&#x299E</span><span class="text">⦞</span><span class="name">Angle with S Inside</li>
-        <li><span class="unicode" role="math">&#x299F</span><span class="text">⦟</span><span class="name">Acute Angle</li>
-        <li><span class="unicode" role="math">&#x29A0</span><span class="text">⦠</span><span class="name">Spherical Angle Opening Left</li>
-        <li><span class="unicode" role="math">&#x29A1</span><span class="text">⦡</span><span class="name">Spherical Angle Opening Up</li>
-        <li><span class="unicode" role="math">&#x29A2</span><span class="text">⦢</span><span class="name">Turned Angle</li>
-        <li><span class="unicode" role="math">&#x29A3</span><span class="text">⦣</span><span class="name">Reversed Angle</li>
-        <li><span class="unicode" role="math">&#x29A4</span><span class="text">⦤</span><span class="name">Angle with Underbar</li>
-        <li><span class="unicode" role="math">&#x29A5</span><span class="text">⦥</span><span class="name">Reversed Angle with Underbar</li>
-        <li><span class="unicode" role="math">&#x29A6</span><span class="text">⦦</span><span class="name">Oblique Angle Opening Up</li>
-        <li><span class="unicode" role="math">&#x29A7</span><span class="text">⦧</span><span class="name">Oblique Angle Opening Down</li>
-        <li><span class="unicode" role="math">&#x29A8</span><span class="text">⦨</span><span class="name">Measured Angle with Open Arm Ending In Arrow Pointing Up and Right</li>
-        <li><span class="unicode" role="math">&#x29A9</span><span class="text">⦩</span><span class="name">Measured Angle with Open Arm Ending In Arrow Pointing Up and Left</li>
-        <li><span class="unicode" role="math">&#x29AA</span><span class="text">⦪</span><span class="name">Measured Angle with Open Arm Ending In Arrow Pointing Down and Right</li>
-        <li><span class="unicode" role="math">&#x29AB</span><span class="text">⦫</span><span class="name">Measured Angle with Open Arm Ending In Arrow Pointing Down and Left</li>
-        <li><span class="unicode" role="math">&#x29AC</span><span class="text">⦬</span><span class="name">Measured Angle with Open Arm Ending In Arrow Pointing Right and Up</li>
-        <li><span class="unicode" role="math">&#x29AD</span><span class="text">⦭</span><span class="name">Measured Angle with Open Arm Ending In Arrow Pointing Left and Up</li>
-        <li><span class="unicode" role="math">&#x29AE</span><span class="text">⦮</span><span class="name">Measured Angle with Open Arm Ending In Arrow Pointing Right and Down</li>
-        <li><span class="unicode" role="math">&#x29AF</span><span class="text">⦯</span><span class="name">Measured Angle with Open Arm Ending In Arrow Pointing Left and Down</li>
-        <li><span class="unicode" role="math">&#x29B0</span><span class="text">⦰</span><span class="name">Reversed Empty Set</li>
-        <li><span class="unicode" role="math">&#x29B1</span><span class="text">⦱</span><span class="name">Empty Set with Overbar</li>
-        <li><span class="unicode" role="math">&#x29B2</span><span class="text">⦲</span><span class="name">Empty Set with Small Circle Above</li>
-        <li><span class="unicode" role="math">&#x29B3</span><span class="text">⦳</span><span class="name">Empty Set with Right Arrow Above</li>
-        <li><span class="unicode" role="math">&#x29B4</span><span class="text">⦴</span><span class="name">Empty Set with Left Arrow Above</li>
-        <li><span class="unicode" role="math">&#x29B5</span><span class="text">⦵</span><span class="name">Circle with Horizontal Bar</li>
-        <li><span class="unicode" role="math">&#x29B6</span><span class="text">⦶</span><span class="name">Circled Vertical Bar</li>
-        <li><span class="unicode" role="math">&#x29B7</span><span class="text">⦷</span><span class="name">Circled Parallel</li>
-        <li><span class="unicode" role="math">&#x29B8</span><span class="text">⦸</span><span class="name">Circled Reverse Solidus</li>
-        <li><span class="unicode" role="math">&#x29B9</span><span class="text">⦹</span><span class="name">Circled Perpendicular</li>
-        <li><span class="unicode" role="math">&#x29BA</span><span class="text">⦺</span><span class="name">Circle Divided By Horizontal Bar and Top Half Divided By Vertical Bar</li>
-        <li><span class="unicode" role="math">&#x29BB</span><span class="text">⦻</span><span class="name">Circle with Superimposed X</li>
-        <li><span class="unicode" role="math">&#x29BC</span><span class="text">⦼</span><span class="name">Circled Anticlockwise-Rotated Division Sign</li>
-        <li><span class="unicode" role="math">&#x29BD</span><span class="text">⦽</span><span class="name">Up Arrow Through Circle</li>
-        <li><span class="unicode" role="math">&#x29BE</span><span class="text">⦾</span><span class="name">Circled White Bullet</li>
-        <li><span class="unicode" role="math">&#x29BF</span><span class="text">⦿</span><span class="name">Circled Bullet</li>
-        <li><span class="unicode" role="math">&#x29C0</span><span class="text">⧀</span><span class="name">Circled Less-Than</li>
-        <li><span class="unicode" role="math">&#x29C1</span><span class="text">⧁</span><span class="name">Circled Greater-Than</li>
-        <li><span class="unicode" role="math">&#x29C2</span><span class="text">⧂</span><span class="name">Circle with Small Circle to the Right</li>
-        <li><span class="unicode" role="math">&#x29C3</span><span class="text">⧃</span><span class="name">Circle with Two Horizontal Strokes to the Right</li>
-        <li><span class="unicode" role="math">&#x29C4</span><span class="text">⧄</span><span class="name">Squared Rising Diagonal Slash</li>
-        <li><span class="unicode" role="math">&#x29C5</span><span class="text">⧅</span><span class="name">Squared Falling Diagonal Slash</li>
-        <li><span class="unicode" role="math">&#x29C6</span><span class="text">⧆</span><span class="name">Squared Asterisk</li>
-        <li><span class="unicode" role="math">&#x29C7</span><span class="text">⧇</span><span class="name">Squared Small Circle</li>
-        <li><span class="unicode" role="math">&#x29C8</span><span class="text">⧈</span><span class="name">Squared Square</li>
-        <li><span class="unicode" role="math">&#x29C9</span><span class="text">⧉</span><span class="name">Two Joined Squares</li>
-        <li><span class="unicode" role="math">&#x29CA</span><span class="text">⧊</span><span class="name">Triangle with Dot Above</li>
-        <li><span class="unicode" role="math">&#x29CB</span><span class="text">⧋</span><span class="name">Triangle with Underbar</li>
-        <li><span class="unicode" role="math">&#x29CC</span><span class="text">⧌</span><span class="name">S In Triangle</li>
-        <li><span class="unicode" role="math">&#x29CD</span><span class="text">⧍</span><span class="name">Triangle with Serifs at Bottom</li>
-        <li><span class="unicode" role="math">&#x29CE</span><span class="text">⧎</span><span class="name">Right Triangle Above Left Triangle</li>
-        <li><span class="unicode" role="math">&#x29CF</span><span class="text">⧏</span><span class="name">Left Triangle Beside Vertical Bar</li>
-        <li><span class="unicode" role="math">&#x29D0</span><span class="text">⧐</span><span class="name">Vertical Bar Beside Right Triangle</li>
-        <li><span class="unicode" role="math">&#x29D1</span><span class="text">⧑</span><span class="name">Bowtie with Left Half Black</li>
-        <li><span class="unicode" role="math">&#x29D2</span><span class="text">⧒</span><span class="name">Bowtie with Right Half Black</li>
-        <li><span class="unicode" role="math">&#x29D3</span><span class="text">⧓</span><span class="name">Black Bowtie</li>
-        <li><span class="unicode" role="math">&#x29D4</span><span class="text">⧔</span><span class="name">Times with Left Half Black</li>
-        <li><span class="unicode" role="math">&#x29D5</span><span class="text">⧕</span><span class="name">Times with Right Half Black</li>
-        <li><span class="unicode" role="math">&#x29D6</span><span class="text">⧖</span><span class="name">White Hourglass</li>
-        <li><span class="unicode" role="math">&#x29D7</span><span class="text">⧗</span><span class="name">Black Hourglass</li>
-        <li><span class="unicode" role="math">&#x29DC</span><span class="text">⧜</span><span class="name">Incomplete Infinity</li>
-        <li><span class="unicode" role="math">&#x29DD</span><span class="text">⧝</span><span class="name">Tie Over Infinity</li>
-        <li><span class="unicode" role="math">&#x29DE</span><span class="text">⧞</span><span class="name">Infinity Negated with Vertical Bar</li>
-        <li><span class="unicode" role="math">&#x29DF</span><span class="text">⧟</span><span class="name">Double-Ended Multimap</li>
-        <li><span class="unicode" role="math">&#x29E0</span><span class="text">⧠</span><span class="name">Square with Contoured Outline</li>
-        <li><span class="unicode" role="math">&#x29E1</span><span class="text">⧡</span><span class="name">Increases As</li>
-        <li><span class="unicode" role="math">&#x29E2</span><span class="text">⧢</span><span class="name">Shuffle Product</li>
-        <li><span class="unicode" role="math">&#x29E3</span><span class="text">⧣</span><span class="name">Equals Sign and Slanted Parallel</li>
-        <li><span class="unicode" role="math">&#x29E4</span><span class="text">⧤</span><span class="name">Equals Sign and Slanted Parallel with Tilde Above</li>
-        <li><span class="unicode" role="math">&#x29E5</span><span class="text">⧥</span><span class="name">Identical to and Slanted Parallel</li>
-        <li><span class="unicode" role="math">&#x29E6</span><span class="text">⧦</span><span class="name">Gleich Stark</li>
-        <li><span class="unicode" role="math">&#x29E7</span><span class="text">⧧</span><span class="name">Thermodynamic</li>
-        <li><span class="unicode" role="math">&#x29E8</span><span class="text">⧨</span><span class="name">Down-Pointing Triangle with Left Half Black</li>
-        <li><span class="unicode" role="math">&#x29E9</span><span class="text">⧩</span><span class="name">Down-Pointing Triangle with Right Half Black</li>
-        <li><span class="unicode" role="math">&#x29EA</span><span class="text">⧪</span><span class="name">Black Diamond with Down Arrow</li>
-        <li><span class="unicode" role="math">&#x29EB</span><span class="text">⧫</span><span class="name">Black Lozenge</li>
-        <li><span class="unicode" role="math">&#x29EC</span><span class="text">⧬</span><span class="name">White Circle with Down Arrow</li>
-        <li><span class="unicode" role="math">&#x29ED</span><span class="text">⧭</span><span class="name">Black Circle with Down Arrow</li>
-        <li><span class="unicode" role="math">&#x29EE</span><span class="text">⧮</span><span class="name">Error-Barred White Square</li>
-        <li><span class="unicode" role="math">&#x29EF</span><span class="text">⧯</span><span class="name">Error-Barred Black Square</li>
-        <li><span class="unicode" role="math">&#x29F0</span><span class="text">⧰</span><span class="name">Error-Barred White Diamond</li>
-        <li><span class="unicode" role="math">&#x29F1</span><span class="text">⧱</span><span class="name">Error-Barred Black Diamond</li>
-        <li><span class="unicode" role="math">&#x29F2</span><span class="text">⧲</span><span class="name">Error-Barred White Circle</li>
-        <li><span class="unicode" role="math">&#x29F3</span><span class="text">⧳</span><span class="name">Error-Barred Black Circle</li>
-        <li><span class="unicode" role="math">&#x29F4</span><span class="text">⧴</span><span class="name">Rule-Delayed</li>
-        <li><span class="unicode" role="math">&#x29F5</span><span class="text">⧵</span><span class="name">Reverse Solidus Operator</li>
-        <li><span class="unicode" role="math">&#x29F6</span><span class="text">⧶</span><span class="name">Solidus with Overbar</li>
-        <li><span class="unicode" role="math">&#x29F7</span><span class="text">⧷</span><span class="name">Reverse Solidus with Horizontal Stroke</li>
-        <li><span class="unicode" role="math">&#x29F8</span><span class="text">⧸</span><span class="name">Big Solidus</li>
-        <li><span class="unicode" role="math">&#x29F9</span><span class="text">⧹</span><span class="name">Big Reverse Solidus</li>
-        <li><span class="unicode" role="math">&#x29FA</span><span class="text">⧺</span><span class="name">Double Plus</li>
-        <li><span class="unicode" role="math">&#x29FB</span><span class="text">⧻</span><span class="name">Triple Plus</li>
-        <li><span class="unicode" role="math">&#x29FE</span><span class="text">⧾</span><span class="name">Tiny</li>
-        <li><span class="unicode" role="math">&#x29FF</span><span class="text">⧿</span><span class="name">Miny</li>
-        <li><span class="unicode" role="math">&#x2A00</span><span class="text">⨀</span><span class="name">N-Ary Circled Dot Operator</li>
-        <li><span class="unicode" role="math">&#x2A01</span><span class="text">⨁</span><span class="name">N-Ary Circled Plus Operator</li>
-        <li><span class="unicode" role="math">&#x2A02</span><span class="text">⨂</span><span class="name">N-Ary Circled Times Operator</li>
-        <li><span class="unicode" role="math">&#x2A03</span><span class="text">⨃</span><span class="name">N-Ary Union Operator with Dot</li>
-        <li><span class="unicode" role="math">&#x2A04</span><span class="text">⨄</span><span class="name">N-Ary Union Operator with Plus</li>
-        <li><span class="unicode" role="math">&#x2A05</span><span class="text">⨅</span><span class="name">N-Ary Square Intersection Operator</li>
-        <li><span class="unicode" role="math">&#x2A06</span><span class="text">⨆</span><span class="name">N-Ary Square Union Operator</li>
-        <li><span class="unicode" role="math">&#x2A07</span><span class="text">⨇</span><span class="name">Two Logical and Operator</li>
-        <li><span class="unicode" role="math">&#x2A08</span><span class="text">⨈</span><span class="name">Two Logical or Operator</li>
-        <li><span class="unicode" role="math">&#x2A09</span><span class="text">⨉</span><span class="name">N-Ary Times Operator</li>
-        <li><span class="unicode" role="math">&#x2A0A</span><span class="text">⨊</span><span class="name">Modulo Two Sum</li>
-        <li><span class="unicode" role="math">&#x2A0B</span><span class="text">⨋</span><span class="name">Summation with Integral</li>
-        <li><span class="unicode" role="math">&#x2A0C</span><span class="text">⨌</span><span class="name">Quadruple Integral Operator</li>
-        <li><span class="unicode" role="math">&#x2A0D</span><span class="text">⨍</span><span class="name">Finite Part Integral</li>
-        <li><span class="unicode" role="math">&#x2A0E</span><span class="text">⨎</span><span class="name">Integral with Double Stroke</li>
-        <li><span class="unicode" role="math">&#x2A0F</span><span class="text">⨏</span><span class="name">Integral Average with Slash</li>
-        <li><span class="unicode" role="math">&#x2A10</span><span class="text">⨐</span><span class="name">Circulation Function</li>
-        <li><span class="unicode" role="math">&#x2A11</span><span class="text">⨑</span><span class="name">Anticlockwise Integration</li>
-        <li><span class="unicode" role="math">&#x2A12</span><span class="text">⨒</span><span class="name">Line Integration with Rectangular Path Around Pole</li>
-        <li><span class="unicode" role="math">&#x2A13</span><span class="text">⨓</span><span class="name">Line Integration with Semicircular Path Around Pole</li>
-        <li><span class="unicode" role="math">&#x2A14</span><span class="text">⨔</span><span class="name">Line Integration Not Including the Pole</li>
-        <li><span class="unicode" role="math">&#x2A15</span><span class="text">⨕</span><span class="name">Integral Around A Point Operator</li>
-        <li><span class="unicode" role="math">&#x2A16</span><span class="text">⨖</span><span class="name">Quaternion Integral Operator</li>
-        <li><span class="unicode" role="math">&#x2A17</span><span class="text">⨗</span><span class="name">Integral with Leftwards Arrow with Hook</li>
-        <li><span class="unicode" role="math">&#x2A18</span><span class="text">⨘</span><span class="name">Integral with Times Sign</li>
-        <li><span class="unicode" role="math">&#x2A19</span><span class="text">⨙</span><span class="name">Integral with Intersection</li>
-        <li><span class="unicode" role="math">&#x2A1A</span><span class="text">⨚</span><span class="name">Integral with Union</li>
-        <li><span class="unicode" role="math">&#x2A1B</span><span class="text">⨛</span><span class="name">Integral with Overbar</li>
-        <li><span class="unicode" role="math">&#x2A1C</span><span class="text">⨜</span><span class="name">Integral with Underbar</li>
-        <li><span class="unicode" role="math">&#x2A1D</span><span class="text">⨝</span><span class="name">Join</li>
-        <li><span class="unicode" role="math">&#x2A1E</span><span class="text">⨞</span><span class="name">Large Left Triangle Operator</li>
-        <li><span class="unicode" role="math">&#x2A1F</span><span class="text">⨟</span><span class="name">Z Notation Schema Composition</li>
-        <li><span class="unicode" role="math">&#x2A20</span><span class="text">⨠</span><span class="name">Z Notation Schema Piping</li>
-        <li><span class="unicode" role="math">&#x2A21</span><span class="text">⨡</span><span class="name">Z Notation Schema Projection</li>
-        <li><span class="unicode" role="math">&#x2A22</span><span class="text">⨢</span><span class="name">Plus Sign with Small Circle Above</li>
-        <li><span class="unicode" role="math">&#x2A23</span><span class="text">⨣</span><span class="name">Plus Sign with Circumflex Accent Above</li>
-        <li><span class="unicode" role="math">&#x2A24</span><span class="text">⨤</span><span class="name">Plus Sign with Tilde Above</li>
-        <li><span class="unicode" role="math">&#x2A25</span><span class="text">⨥</span><span class="name">Plus Sign with Dot Below</li>
-        <li><span class="unicode" role="math">&#x2A26</span><span class="text">⨦</span><span class="name">Plus Sign with Tilde Below</li>
-        <li><span class="unicode" role="math">&#x2A27</span><span class="text">⨧</span><span class="name">Plus Sign with Subscript Two</li>
-        <li><span class="unicode" role="math">&#x2A28</span><span class="text">⨨</span><span class="name">Plus Sign with Black Triangle</li>
-        <li><span class="unicode" role="math">&#x2A29</span><span class="text">⨩</span><span class="name">Minus Sign with Comma Above</li>
-        <li><span class="unicode" role="math">&#x2A2A</span><span class="text">⨪</span><span class="name">Minus Sign with Dot Below</li>
-        <li><span class="unicode" role="math">&#x2A2B</span><span class="text">⨫</span><span class="name">Minus Sign with Falling Dots</li>
-        <li><span class="unicode" role="math">&#x2A2C</span><span class="text">⨬</span><span class="name">Minus Sign with Rising Dots</li>
-        <li><span class="unicode" role="math">&#x2A2D</span><span class="text">⨭</span><span class="name">Plus Sign In Left Half Circle</li>
-        <li><span class="unicode" role="math">&#x2A2E</span><span class="text">⨮</span><span class="name">Plus Sign In Right Half Circle</li>
-        <li><span class="unicode" role="math">&#x2A2F</span><span class="text">⨯</span><span class="name">Vector or Cross Product</li>
-        <li><span class="unicode" role="math">&#x2A30</span><span class="text">⨰</span><span class="name">Multiplication Sign with Dot Above</li>
-        <li><span class="unicode" role="math">&#x2A31</span><span class="text">⨱</span><span class="name">Multiplication Sign with Underbar</li>
-        <li><span class="unicode" role="math">&#x2A32</span><span class="text">⨲</span><span class="name">Semidirect Product with Bottom Closed</li>
-        <li><span class="unicode" role="math">&#x2A33</span><span class="text">⨳</span><span class="name">Smash Product</li>
-        <li><span class="unicode" role="math">&#x2A34</span><span class="text">⨴</span><span class="name">Multiplication Sign In Left Half Circle</li>
-        <li><span class="unicode" role="math">&#x2A35</span><span class="text">⨵</span><span class="name">Multiplication Sign In Right Half Circle</li>
-        <li><span class="unicode" role="math">&#x2A36</span><span class="text">⨶</span><span class="name">Circled Multiplication Sign with Circumflex Accent</li>
-        <li><span class="unicode" role="math">&#x2A37</span><span class="text">⨷</span><span class="name">Multiplication Sign In Double Circle</li>
-        <li><span class="unicode" role="math">&#x2A38</span><span class="text">⨸</span><span class="name">Circled Division Sign</li>
-        <li><span class="unicode" role="math">&#x2A39</span><span class="text">⨹</span><span class="name">Plus Sign In Triangle</li>
-        <li><span class="unicode" role="math">&#x2A3A</span><span class="text">⨺</span><span class="name">Minus Sign In Triangle</li>
-        <li><span class="unicode" role="math">&#x2A3B</span><span class="text">⨻</span><span class="name">Multiplication Sign In Triangle</li>
-        <li><span class="unicode" role="math">&#x2A3C</span><span class="text">⨼</span><span class="name">Interior Product</li>
-        <li><span class="unicode" role="math">&#x2A3D</span><span class="text">⨽</span><span class="name">Righthand Interior Product</li>
-        <li><span class="unicode" role="math">&#x2A3E</span><span class="text">⨾</span><span class="name">Z Notation Relational Composition</li>
-        <li><span class="unicode" role="math">&#x2A3F</span><span class="text">⨿</span><span class="name">Amalgamation or Coproduct</li>
-        <li><span class="unicode" role="math">&#x2A40</span><span class="text">⩀</span><span class="name">Intersection with Dot</li>
-        <li><span class="unicode" role="math">&#x2A41</span><span class="text">⩁</span><span class="name">Union with Minus Sign</li>
-        <li><span class="unicode" role="math">&#x2A42</span><span class="text">⩂</span><span class="name">Union with Overbar</li>
-        <li><span class="unicode" role="math">&#x2A43</span><span class="text">⩃</span><span class="name">Intersection with Overbar</li>
-        <li><span class="unicode" role="math">&#x2A44</span><span class="text">⩄</span><span class="name">Intersection with Logical And</li>
-        <li><span class="unicode" role="math">&#x2A45</span><span class="text">⩅</span><span class="name">Union with Logical Or</li>
-        <li><span class="unicode" role="math">&#x2A46</span><span class="text">⩆</span><span class="name">Union Above Intersection</li>
-        <li><span class="unicode" role="math">&#x2A47</span><span class="text">⩇</span><span class="name">Intersection Above Union</li>
-        <li><span class="unicode" role="math">&#x2A48</span><span class="text">⩈</span><span class="name">Union Above Bar Above Intersection</li>
-        <li><span class="unicode" role="math">&#x2A49</span><span class="text">⩉</span><span class="name">Intersection Above Bar Above Union</li>
-        <li><span class="unicode" role="math">&#x2A4A</span><span class="text">⩊</span><span class="name">Union Beside and Joined with Union</li>
-        <li><span class="unicode" role="math">&#x2A4B</span><span class="text">⩋</span><span class="name">Intersection Beside and Joined with Intersection</li>
-        <li><span class="unicode" role="math">&#x2A4C</span><span class="text">⩌</span><span class="name">Closed Union with Serifs</li>
-        <li><span class="unicode" role="math">&#x2A4D</span><span class="text">⩍</span><span class="name">Closed Intersection with Serifs</li>
-        <li><span class="unicode" role="math">&#x2A4E</span><span class="text">⩎</span><span class="name">Double Square Intersection</li>
-        <li><span class="unicode" role="math">&#x2A4F</span><span class="text">⩏</span><span class="name">Double Square Union</li>
-        <li><span class="unicode" role="math">&#x2A50</span><span class="text">⩐</span><span class="name">Closed Union with Serifs and Smash Product</li>
-        <li><span class="unicode" role="math">&#x2A51</span><span class="text">⩑</span><span class="name">Logical and with Dot Above</li>
-        <li><span class="unicode" role="math">&#x2A52</span><span class="text">⩒</span><span class="name">Logical or with Dot Above</li>
-        <li><span class="unicode" role="math">&#x2A53</span><span class="text">⩓</span><span class="name">Double Logical And</li>
-        <li><span class="unicode" role="math">&#x2A54</span><span class="text">⩔</span><span class="name">Double Logical Or</li>
-        <li><span class="unicode" role="math">&#x2A55</span><span class="text">⩕</span><span class="name">Two Intersecting Logical And</li>
-        <li><span class="unicode" role="math">&#x2A56</span><span class="text">⩖</span><span class="name">Two Intersecting Logical Or</li>
-        <li><span class="unicode" role="math">&#x2A57</span><span class="text">⩗</span><span class="name">Sloping Large Or</li>
-        <li><span class="unicode" role="math">&#x2A58</span><span class="text">⩘</span><span class="name">Sloping Large And</li>
-        <li><span class="unicode" role="math">&#x2A59</span><span class="text">⩙</span><span class="name">Logical or Overlapping Logical And</li>
-        <li><span class="unicode" role="math">&#x2A5A</span><span class="text">⩚</span><span class="name">Logical and with Middle Stem</li>
-        <li><span class="unicode" role="math">&#x2A5B</span><span class="text">⩛</span><span class="name">Logical or with Middle Stem</li>
-        <li><span class="unicode" role="math">&#x2A5C</span><span class="text">⩜</span><span class="name">Logical and with Horizontal Dash</li>
-        <li><span class="unicode" role="math">&#x2A5D</span><span class="text">⩝</span><span class="name">Logical or with Horizontal Dash</li>
-        <li><span class="unicode" role="math">&#x2A5E</span><span class="text">⩞</span><span class="name">Logical and with Double Overbar</li>
-        <li><span class="unicode" role="math">&#x2A5F</span><span class="text">⩟</span><span class="name">Logical and with Underbar</li>
-        <li><span class="unicode" role="math">&#x2A60</span><span class="text">⩠</span><span class="name">Logical and with Double Underbar</li>
-        <li><span class="unicode" role="math">&#x2A61</span><span class="text">⩡</span><span class="name">Small Vee with Underbar</li>
-        <li><span class="unicode" role="math">&#x2A62</span><span class="text">⩢</span><span class="name">Logical or with Double Overbar</li>
-        <li><span class="unicode" role="math">&#x2A63</span><span class="text">⩣</span><span class="name">Logical or with Double Underbar</li>
-        <li><span class="unicode" role="math">&#x2A64</span><span class="text">⩤</span><span class="name">Z Notation Domain Antirestriction</li>
-        <li><span class="unicode" role="math">&#x2A65</span><span class="text">⩥</span><span class="name">Z Notation Range Antirestriction</li>
-        <li><span class="unicode" role="math">&#x2A66</span><span class="text">⩦</span><span class="name">Equals Sign with Dot Below</li>
-        <li><span class="unicode" role="math">&#x2A67</span><span class="text">⩧</span><span class="name">Identical with Dot Above</li>
-        <li><span class="unicode" role="math">&#x2A68</span><span class="text">⩨</span><span class="name">Triple Horizontal Bar with Double Vertical Stroke</li>
-        <li><span class="unicode" role="math">&#x2A69</span><span class="text">⩩</span><span class="name">Triple Horizontal Bar with Triple Vertical Stroke</li>
-        <li><span class="unicode" role="math">&#x2A6A</span><span class="text">⩪</span><span class="name">Tilde Operator with Dot Above</li>
-        <li><span class="unicode" role="math">&#x2A6B</span><span class="text">⩫</span><span class="name">Tilde Operator with Rising Dots</li>
-        <li><span class="unicode" role="math">&#x2A6C</span><span class="text">⩬</span><span class="name">Similar Minus Similar</li>
-        <li><span class="unicode" role="math">&#x2A6D</span><span class="text">⩭</span><span class="name">Congruent with Dot Above</li>
-        <li><span class="unicode" role="math">&#x2A6E</span><span class="text">⩮</span><span class="name">Equals with Asterisk</li>
-        <li><span class="unicode" role="math">&#x2A6F</span><span class="text">⩯</span><span class="name">Almost Equal to with Circumflex Accent</li>
-        <li><span class="unicode" role="math">&#x2A70</span><span class="text">⩰</span><span class="name">Approximately Equal or Equal To</li>
-        <li><span class="unicode" role="math">&#x2A71</span><span class="text">⩱</span><span class="name">Equals Sign Above Plus Sign</li>
-        <li><span class="unicode" role="math">&#x2A72</span><span class="text">⩲</span><span class="name">Plus Sign Above Equals Sign</li>
-        <li><span class="unicode" role="math">&#x2A73</span><span class="text">⩳</span><span class="name">Equals Sign Above Tilde Operator</li>
-        <li><span class="unicode" role="math">&#x2A74</span><span class="text">⩴</span><span class="name">Double Colon Equal</li>
-        <li><span class="unicode" role="math">&#x2A75</span><span class="text">⩵</span><span class="name">Two Consecutive Equals Signs</li>
-        <li><span class="unicode" role="math">&#x2A76</span><span class="text">⩶</span><span class="name">Three Consecutive Equals Signs</li>
-        <li><span class="unicode" role="math">&#x2A77</span><span class="text">⩷</span><span class="name">Equals Sign with Two Dots Above and Two Dots Below</li>
-        <li><span class="unicode" role="math">&#x2A78</span><span class="text">⩸</span><span class="name">Equivalent with Four Dots Above</li>
-        <li><span class="unicode" role="math">&#x2A79</span><span class="text">⩹</span><span class="name">Less-Than with Circle Inside</li>
-        <li><span class="unicode" role="math">&#x2A7A</span><span class="text">⩺</span><span class="name">Greater-Than with Circle Inside</li>
-        <li><span class="unicode" role="math">&#x2A7B</span><span class="text">⩻</span><span class="name">Less-Than with Question Mark Above</li>
-        <li><span class="unicode" role="math">&#x2A7C</span><span class="text">⩼</span><span class="name">Greater-Than with Question Mark Above</li>
-        <li><span class="unicode" role="math">&#x2A7D</span><span class="text">⩽</span><span class="name">Less-Than or Slanted Equal To</li>
-        <li><span class="unicode" role="math">&#x2A7E</span><span class="text">⩾</span><span class="name">Greater-Than or Slanted Equal To</li>
-        <li><span class="unicode" role="math">&#x2A7F</span><span class="text">⩿</span><span class="name">Less-Than or Slanted Equal to with Dot Inside</li>
-        <li><span class="unicode" role="math">&#x2A80</span><span class="text">⪀</span><span class="name">Greater-Than or Slanted Equal to with Dot Inside</li>
-        <li><span class="unicode" role="math">&#x2A81</span><span class="text">⪁</span><span class="name">Less-Than or Slanted Equal to with Dot Above</li>
-        <li><span class="unicode" role="math">&#x2A82</span><span class="text">⪂</span><span class="name">Greater-Than or Slanted Equal to with Dot Above</li>
-        <li><span class="unicode" role="math">&#x2A83</span><span class="text">⪃</span><span class="name">Less-Than or Slanted Equal to with Dot Above Right</li>
-        <li><span class="unicode" role="math">&#x2A84</span><span class="text">⪄</span><span class="name">Greater-Than or Slanted Equal to with Dot Above Left</li>
-        <li><span class="unicode" role="math">&#x2A85</span><span class="text">⪅</span><span class="name">Less-Than or Approximate</li>
-        <li><span class="unicode" role="math">&#x2A86</span><span class="text">⪆</span><span class="name">Greater-Than or Approximate</li>
-        <li><span class="unicode" role="math">&#x2A87</span><span class="text">⪇</span><span class="name">Less-Than and Single-Line Not Equal To</li>
-        <li><span class="unicode" role="math">&#x2A88</span><span class="text">⪈</span><span class="name">Greater-Than and Single-Line Not Equal To</li>
-        <li><span class="unicode" role="math">&#x2A89</span><span class="text">⪉</span><span class="name">Less-Than and Not Approximate</li>
-        <li><span class="unicode" role="math">&#x2A8A</span><span class="text">⪊</span><span class="name">Greater-Than and Not Approximate</li>
-        <li><span class="unicode" role="math">&#x2A8B</span><span class="text">⪋</span><span class="name">Less-Than Above Double-Line Equal Above Greater-Than</li>
-        <li><span class="unicode" role="math">&#x2A8C</span><span class="text">⪌</span><span class="name">Greater-Than Above Double-Line Equal Above Less-Than</li>
-        <li><span class="unicode" role="math">&#x2A8D</span><span class="text">⪍</span><span class="name">Less-Than Above Similar or Equal</li>
-        <li><span class="unicode" role="math">&#x2A8E</span><span class="text">⪎</span><span class="name">Greater-Than Above Similar or Equal</li>
-        <li><span class="unicode" role="math">&#x2A8F</span><span class="text">⪏</span><span class="name">Less-Than Above Similar Above Greater-Than</li>
-        <li><span class="unicode" role="math">&#x2A90</span><span class="text">⪐</span><span class="name">Greater-Than Above Similar Above Less-Than</li>
-        <li><span class="unicode" role="math">&#x2A91</span><span class="text">⪑</span><span class="name">Less-Than Above Greater-Than Above Double-Line Equal</li>
-        <li><span class="unicode" role="math">&#x2A92</span><span class="text">⪒</span><span class="name">Greater-Than Above Less-Than Above Double-Line Equal</li>
-        <li><span class="unicode" role="math">&#x2A93</span><span class="text">⪓</span><span class="name">Less-Than Above Slanted Equal Above Greater-Than Above Slanted Equal</li>
-        <li><span class="unicode" role="math">&#x2A94</span><span class="text">⪔</span><span class="name">Greater-Than Above Slanted Equal Above Less-Than Above Slanted Equal</li>
-        <li><span class="unicode" role="math">&#x2A95</span><span class="text">⪕</span><span class="name">Slanted Equal to or Less-Than</li>
-        <li><span class="unicode" role="math">&#x2A96</span><span class="text">⪖</span><span class="name">Slanted Equal to or Greater-Than</li>
-        <li><span class="unicode" role="math">&#x2A97</span><span class="text">⪗</span><span class="name">Slanted Equal to or Less-Than with Dot Inside</li>
-        <li><span class="unicode" role="math">&#x2A98</span><span class="text">⪘</span><span class="name">Slanted Equal to or Greater-Than with Dot Inside</li>
-        <li><span class="unicode" role="math">&#x2A99</span><span class="text">⪙</span><span class="name">Double-Line Equal to or Less-Than</li>
-        <li><span class="unicode" role="math">&#x2A9A</span><span class="text">⪚</span><span class="name">Double-Line Equal to or Greater-Than</li>
-        <li><span class="unicode" role="math">&#x2A9B</span><span class="text">⪛</span><span class="name">Double-Line Slanted Equal to or Less-Than</li>
-        <li><span class="unicode" role="math">&#x2A9C</span><span class="text">⪜</span><span class="name">Double-Line Slanted Equal to or Greater-Than</li>
-        <li><span class="unicode" role="math">&#x2A9D</span><span class="text">⪝</span><span class="name">Similar or Less-Than</li>
-        <li><span class="unicode" role="math">&#x2A9E</span><span class="text">⪞</span><span class="name">Similar or Greater-Than</li>
-        <li><span class="unicode" role="math">&#x2A9F</span><span class="text">⪟</span><span class="name">Similar Above Less-Than Above Equals Sign</li>
-        <li><span class="unicode" role="math">&#x2AA0</span><span class="text">⪠</span><span class="name">Similar Above Greater-Than Above Equals Sign</li>
-        <li><span class="unicode" role="math">&#x2AA1</span><span class="text">⪡</span><span class="name">Double Nested Less-Than</li>
-        <li><span class="unicode" role="math">&#x2AA2</span><span class="text">⪢</span><span class="name">Double Nested Greater-Than</li>
-        <li><span class="unicode" role="math">&#x2AA3</span><span class="text">⪣</span><span class="name">Double Nested Less-Than with Underbar</li>
-        <li><span class="unicode" role="math">&#x2AA4</span><span class="text">⪤</span><span class="name">Greater-Than Overlapping Less-Than</li>
-        <li><span class="unicode" role="math">&#x2AA5</span><span class="text">⪥</span><span class="name">Greater-Than Beside Less-Than</li>
-        <li><span class="unicode" role="math">&#x2AA6</span><span class="text">⪦</span><span class="name">Less-Than Closed By Curve</li>
-        <li><span class="unicode" role="math">&#x2AA7</span><span class="text">⪧</span><span class="name">Greater-Than Closed By Curve</li>
-        <li><span class="unicode" role="math">&#x2AA8</span><span class="text">⪨</span><span class="name">Less-Than Closed By Curve Above Slanted Equal</li>
-        <li><span class="unicode" role="math">&#x2AA9</span><span class="text">⪩</span><span class="name">Greater-Than Closed By Curve Above Slanted Equal</li>
-        <li><span class="unicode" role="math">&#x2AAA</span><span class="text">⪪</span><span class="name">Smaller Than</li>
-        <li><span class="unicode" role="math">&#x2AAB</span><span class="text">⪫</span><span class="name">Larger Than</li>
-        <li><span class="unicode" role="math">&#x2AAC</span><span class="text">⪬</span><span class="name">Smaller Than or Equal To</li>
-        <li><span class="unicode" role="math">&#x2AAD</span><span class="text">⪭</span><span class="name">Larger Than or Equal To</li>
-        <li><span class="unicode" role="math">&#x2AAE</span><span class="text">⪮</span><span class="name">Equals Sign with Bumpy Above</li>
-        <li><span class="unicode" role="math">&#x2AAF</span><span class="text">⪯</span><span class="name">Precedes Above Single-Line Equals Sign</li>
-        <li><span class="unicode" role="math">&#x2AB0</span><span class="text">⪰</span><span class="name">Succeeds Above Single-Line Equals Sign</li>
-        <li><span class="unicode" role="math">&#x2AB1</span><span class="text">⪱</span><span class="name">Precedes Above Single-Line Not Equal To</li>
-        <li><span class="unicode" role="math">&#x2AB2</span><span class="text">⪲</span><span class="name">Succeeds Above Single-Line Not Equal To</li>
-        <li><span class="unicode" role="math">&#x2AB3</span><span class="text">⪳</span><span class="name">Precedes Above Equals Sign</li>
-        <li><span class="unicode" role="math">&#x2AB4</span><span class="text">⪴</span><span class="name">Succeeds Above Equals Sign</li>
-        <li><span class="unicode" role="math">&#x2AB5</span><span class="text">⪵</span><span class="name">Precedes Above Not Equal To</li>
-        <li><span class="unicode" role="math">&#x2AB6</span><span class="text">⪶</span><span class="name">Succeeds Above Not Equal To</li>
-        <li><span class="unicode" role="math">&#x2AB7</span><span class="text">⪷</span><span class="name">Precedes Above Almost Equal To</li>
-        <li><span class="unicode" role="math">&#x2AB8</span><span class="text">⪸</span><span class="name">Succeeds Above Almost Equal To</li>
-        <li><span class="unicode" role="math">&#x2AB9</span><span class="text">⪹</span><span class="name">Precedes Above Not Almost Equal To</li>
-        <li><span class="unicode" role="math">&#x2ABA</span><span class="text">⪺</span><span class="name">Succeeds Above Not Almost Equal To</li>
-        <li><span class="unicode" role="math">&#x2ABB</span><span class="text">⪻</span><span class="name">Double Precedes</li>
-        <li><span class="unicode" role="math">&#x2ABC</span><span class="text">⪼</span><span class="name">Double Succeeds</li>
-        <li><span class="unicode" role="math">&#x2ABD</span><span class="text">⪽</span><span class="name">Subset with Dot</li>
-        <li><span class="unicode" role="math">&#x2ABE</span><span class="text">⪾</span><span class="name">Superset with Dot</li>
-        <li><span class="unicode" role="math">&#x2ABF</span><span class="text">⪿</span><span class="name">Subset with Plus Sign Below</li>
-        <li><span class="unicode" role="math">&#x2AC0</span><span class="text">⫀</span><span class="name">Superset with Plus Sign Below</li>
-        <li><span class="unicode" role="math">&#x2AC1</span><span class="text">⫁</span><span class="name">Subset with Multiplication Sign Below</li>
-        <li><span class="unicode" role="math">&#x2AC2</span><span class="text">⫂</span><span class="name">Superset with Multiplication Sign Below</li>
-        <li><span class="unicode" role="math">&#x2AC3</span><span class="text">⫃</span><span class="name">Subset of or Equal to with Dot Above</li>
-        <li><span class="unicode" role="math">&#x2AC4</span><span class="text">⫄</span><span class="name">Superset of or Equal to with Dot Above</li>
-        <li><span class="unicode" role="math">&#x2AC5</span><span class="text">⫅</span><span class="name">Subset of Above Equals Sign</li>
-        <li><span class="unicode" role="math">&#x2AC6</span><span class="text">⫆</span><span class="name">Superset of Above Equals Sign</li>
-        <li><span class="unicode" role="math">&#x2AC7</span><span class="text">⫇</span><span class="name">Subset of Above Tilde Operator</li>
-        <li><span class="unicode" role="math">&#x2AC8</span><span class="text">⫈</span><span class="name">Superset of Above Tilde Operator</li>
-        <li><span class="unicode" role="math">&#x2AC9</span><span class="text">⫉</span><span class="name">Subset of Above Almost Equal To</li>
-        <li><span class="unicode" role="math">&#x2ACA</span><span class="text">⫊</span><span class="name">Superset of Above Almost Equal To</li>
-        <li><span class="unicode" role="math">&#x2ACB</span><span class="text">⫋</span><span class="name">Subset of Above Not Equal To</li>
-        <li><span class="unicode" role="math">&#x2ACC</span><span class="text">⫌</span><span class="name">Superset of Above Not Equal To</li>
-        <li><span class="unicode" role="math">&#x2ACD</span><span class="text">⫍</span><span class="name">Square Left Open Box Operator</li>
-        <li><span class="unicode" role="math">&#x2ACE</span><span class="text">⫎</span><span class="name">Square Right Open Box Operator</li>
-        <li><span class="unicode" role="math">&#x2ACF</span><span class="text">⫏</span><span class="name">Closed Subset</li>
-        <li><span class="unicode" role="math">&#x2AD0</span><span class="text">⫐</span><span class="name">Closed Superset</li>
-        <li><span class="unicode" role="math">&#x2AD1</span><span class="text">⫑</span><span class="name">Closed Subset or Equal To</li>
-        <li><span class="unicode" role="math">&#x2AD2</span><span class="text">⫒</span><span class="name">Closed Superset or Equal To</li>
-        <li><span class="unicode" role="math">&#x2AD3</span><span class="text">⫓</span><span class="name">Subset Above Superset</li>
-        <li><span class="unicode" role="math">&#x2AD4</span><span class="text">⫔</span><span class="name">Superset Above Subset</li>
-        <li><span class="unicode" role="math">&#x2AD5</span><span class="text">⫕</span><span class="name">Subset Above Subset</li>
-        <li><span class="unicode" role="math">&#x2AD6</span><span class="text">⫖</span><span class="name">Superset Above Superset</li>
-        <li><span class="unicode" role="math">&#x2AD7</span><span class="text">⫗</span><span class="name">Superset Beside Subset</li>
-        <li><span class="unicode" role="math">&#x2AD8</span><span class="text">⫘</span><span class="name">Superset Beside and Joined By Dash with Subset</li>
-        <li><span class="unicode" role="math">&#x2AD9</span><span class="text">⫙</span><span class="name">Element of Opening Downwards</li>
-        <li><span class="unicode" role="math">&#x2ADA</span><span class="text">⫚</span><span class="name">Pitchfork with Tee Top</li>
-        <li><span class="unicode" role="math">&#x2ADB</span><span class="text">⫛</span><span class="name">Transversal Intersection</li>
-        <li><span class="unicode" role="math">&#x2ADC</span><span class="text">⫝̸</span><span class="name">Forking</li>
-        <li><span class="unicode" role="math">&#x2ADD</span><span class="text">⫝</span><span class="name">Nonforking</li>
-        <li><span class="unicode" role="math">&#x2ADE</span><span class="text">⫞</span><span class="name">Short Left Tack</li>
-        <li><span class="unicode" role="math">&#x2ADF</span><span class="text">⫟</span><span class="name">Short Down Tack</li>
-        <li><span class="unicode" role="math">&#x2AE0</span><span class="text">⫠</span><span class="name">Short Up Tack</li>
-        <li><span class="unicode" role="math">&#x2AE1</span><span class="text">⫡</span><span class="name">Perpendicular with S</li>
-        <li><span class="unicode" role="math">&#x2AE2</span><span class="text">⫢</span><span class="name">Vertical Bar Triple Right Turnstile</li>
-        <li><span class="unicode" role="math">&#x2AE3</span><span class="text">⫣</span><span class="name">Double Vertical Bar Left Turnstile</li>
-        <li><span class="unicode" role="math">&#x2AE4</span><span class="text">⫤</span><span class="name">Vertical Bar Double Left Turnstile</li>
-        <li><span class="unicode" role="math">&#x2AE5</span><span class="text">⫥</span><span class="name">Double Vertical Bar Double Left Turnstile</li>
-        <li><span class="unicode" role="math">&#x2AE6</span><span class="text">⫦</span><span class="name">Long Dash from Left Member of Double Vertical</li>
-        <li><span class="unicode" role="math">&#x2AE7</span><span class="text">⫧</span><span class="name">Short Down Tack with Overbar</li>
-        <li><span class="unicode" role="math">&#x2AE8</span><span class="text">⫨</span><span class="name">Short Up Tack with Underbar</li>
-        <li><span class="unicode" role="math">&#x2AE9</span><span class="text">⫩</span><span class="name">Short Up Tack Above Short Down Tack</li>
-        <li><span class="unicode" role="math">&#x2AEA</span><span class="text">⫪</span><span class="name">Double Down Tack</li>
-        <li><span class="unicode" role="math">&#x2AEB</span><span class="text">⫫</span><span class="name">Double Up Tack</li>
-        <li><span class="unicode" role="math">&#x2AEC</span><span class="text">⫬</span><span class="name">Double Stroke Not Sign</li>
-        <li><span class="unicode" role="math">&#x2AED</span><span class="text">⫭</span><span class="name">Reversed Double Stroke Not Sign</li>
-        <li><span class="unicode" role="math">&#x2AEE</span><span class="text">⫮</span><span class="name">Does Not Divide with Reversed Negation Slash</li>
-        <li><span class="unicode" role="math">&#x2AEF</span><span class="text">⫯</span><span class="name">Vertical Line with Circle Above</li>
-        <li><span class="unicode" role="math">&#x2AF0</span><span class="text">⫰</span><span class="name">Vertical Line with Circle Below</li>
-        <li><span class="unicode" role="math">&#x2AF1</span><span class="text">⫱</span><span class="name">Down Tack with Circle Below</li>
-        <li><span class="unicode" role="math">&#x2AF2</span><span class="text">⫲</span><span class="name">Parallel with Horizontal Stroke</li>
-        <li><span class="unicode" role="math">&#x2AF3</span><span class="text">⫳</span><span class="name">Parallel with Tilde Operator</li>
-        <li><span class="unicode" role="math">&#x2AF4</span><span class="text">⫴</span><span class="name">Triple Vertical Bar Binary Relation</li>
-        <li><span class="unicode" role="math">&#x2AF5</span><span class="text">⫵</span><span class="name">Triple Vertical Bar with Horizontal Stroke</li>
-        <li><span class="unicode" role="math">&#x2AF6</span><span class="text">⫶</span><span class="name">Triple Colon Operator</li>
-        <li><span class="unicode" role="math">&#x2AF7</span><span class="text">⫷</span><span class="name">Triple Nested Less-Than</li>
-        <li><span class="unicode" role="math">&#x2AF8</span><span class="text">⫸</span><span class="name">Triple Nested Greater-Than</li>
-        <li><span class="unicode" role="math">&#x2AF9</span><span class="text">⫹</span><span class="name">Double-Line Slanted Less-Than or Equal To</li>
-        <li><span class="unicode" role="math">&#x2AFA</span><span class="text">⫺</span><span class="name">Double-Line Slanted Greater-Than or Equal To</li>
-        <li><span class="unicode" role="math">&#x2AFB</span><span class="text">⫻</span><span class="name">Triple Solidus Binary Relation</li>
-        <li><span class="unicode" role="math">&#x2AFC</span><span class="text">⫼</span><span class="name">Large Triple Vertical Bar Operator</li>
-        <li><span class="unicode" role="math">&#x2AFD</span><span class="text">⫽</span><span class="name">Double Solidus Operator</li>
-        <li><span class="unicode" role="math">&#x2AFE</span><span class="text">⫾</span><span class="name">White Vertical Bar</li>
-        <li><span class="unicode" role="math">&#x2AFF</span><span class="text">⫿</span><span class="name">N-Ary White Vertical Bar</li>
-        <li><span class="unicode" role="math">&#x2B30</span><span class="text">⬰</span><span class="name">Left Arrow with Small Circle</li>
-        <li><span class="unicode" role="math">&#x2B31</span><span class="text">⬱</span><span class="name">Three Leftwards Arrows</li>
-        <li><span class="unicode" role="math">&#x2B32</span><span class="text">⬲</span><span class="name">Left Arrow with Circled Plus</li>
-        <li><span class="unicode" role="math">&#x2B33</span><span class="text">⬳</span><span class="name">Long Leftwards Squiggle Arrow</li>
-        <li><span class="unicode" role="math">&#x2B34</span><span class="text">⬴</span><span class="name">Leftwards Two-Headed Arrow with Vertical Stroke</li>
-        <li><span class="unicode" role="math">&#x2B35</span><span class="text">⬵</span><span class="name">Leftwards Two-Headed Arrow with Double Vertical Stroke</li>
-        <li><span class="unicode" role="math">&#x2B36</span><span class="text">⬶</span><span class="name">Leftwards Two-Headed Arrow from Bar</li>
-        <li><span class="unicode" role="math">&#x2B37</span><span class="text">⬷</span><span class="name">Leftwards Two-Headed Triple Dash Arrow</li>
-        <li><span class="unicode" role="math">&#x2B38</span><span class="text">⬸</span><span class="name">Leftwards Arrow with Dotted Stem</li>
-        <li><span class="unicode" role="math">&#x2B39</span><span class="text">⬹</span><span class="name">Leftwards Arrow with Tail with Vertical Stroke</li>
-        <li><span class="unicode" role="math">&#x2B3A</span><span class="text">⬺</span><span class="name">Leftwards Arrow with Tail with Double Vertical Stroke</li>
-        <li><span class="unicode" role="math">&#x2B3B</span><span class="text">⬻</span><span class="name">Leftwards Two-Headed Arrow with Tail</li>
-        <li><span class="unicode" role="math">&#x2B3C</span><span class="text">⬼</span><span class="name">Leftwards Two-Headed Arrow with Tail with Vertical Stroke</li>
-        <li><span class="unicode" role="math">&#x2B3D</span><span class="text">⬽</span><span class="name">Leftwards Two-Headed Arrow with Tail with Double Vertical Stroke</li>
-        <li><span class="unicode" role="math">&#x2B3E</span><span class="text">⬾</span><span class="name">Leftwards Arrow Through X</li>
-        <li><span class="unicode" role="math">&#x2B3F</span><span class="text">⬿</span><span class="name">Wave Arrow Pointing Directly Left</li>
-        <li><span class="unicode" role="math">&#x2B40</span><span class="text">⭀</span><span class="name">Equals Sign Above Leftwards Arrow</li>
-        <li><span class="unicode" role="math">&#x2B41</span><span class="text">⭁</span><span class="name">Reverse Tilde Operator Above Leftwards Arrow</li>
-        <li><span class="unicode" role="math">&#x2B42</span><span class="text">⭂</span><span class="name">Leftwards Arrow Above Reverse Almost Equal To</li>
-        <li><span class="unicode" role="math">&#x2B43</span><span class="text">⭃</span><span class="name">Rightwards Arrow Through Greater-Than</li>
-        <li><span class="unicode" role="math">&#x2B44</span><span class="text">⭄</span><span class="name">Rightwards Arrow Through Superset</li>
-        <li><span class="unicode" role="math">&#x2B47</span><span class="text">⭇</span><span class="name">Reverse Tilde Operator Above Rightwards Arrow</li>
-        <li><span class="unicode" role="math">&#x2B48</span><span class="text">⭈</span><span class="name">Rightwards Arrow Above Reverse Almost Equal To</li>
-        <li><span class="unicode" role="math">&#x2B49</span><span class="text">⭉</span><span class="name">Tilde Operator Above Leftwards Arrow</li>
-        <li><span class="unicode" role="math">&#x2B4A</span><span class="text">⭊</span><span class="name">Leftwards Arrow Above Almost Equal To</li>
-        <li><span class="unicode" role="math">&#x2B4B</span><span class="text">⭋</span><span class="name">Leftwards Arrow Above Reverse Tilde Operator</li>
-        <li><span class="unicode" role="math">&#x2B4C</span><span class="text">⭌</span><span class="name">Rightwards Arrow Above Reverse Tilde Operator</li>
-        <li><span class="unicode" role="math">&#xFB29</span><span class="text">﬩</span><span class="name">Hebrew Letter Alternative Plus Sign</li>
-        <li><span class="unicode" role="math">&#xFE62</span><span class="text">﹢</span><span class="name">Small Plus Sign</li>
-        <li><span class="unicode" role="math">&#xFE64</span><span class="text">﹤</span><span class="name">Small Less-Than Sign</li>
-        <li><span class="unicode" role="math">&#xFE65</span><span class="text">﹥</span><span class="name">Small Greater-Than Sign</li>
-        <li><span class="unicode" role="math">&#xFE66</span><span class="text">﹦</span><span class="name">Small Equals Sign</li>
-        <li><span class="unicode" role="math">&#xFF0B</span><span class="text">＋</span><span class="name">Fullwidth Plus Sign</li>
-        <li><span class="unicode" role="math">&#xFF1C</span><span class="text">＜</span><span class="name">Fullwidth Less-Than Sign</li>
-        <li><span class="unicode" role="math">&#xFF1D</span><span class="text">＝</span><span class="name">Fullwidth Equals Sign</li>
-        <li><span class="unicode" role="math">&#xFF1E</span><span class="text">＞</span><span class="name">Fullwidth Greater-Than Sign</li>
-        <li><span class="unicode" role="math">&#xFF5C</span><span class="text">｜</span><span class="name">Fullwidth Vertical Line</li>
-        <li><span class="unicode" role="math">&#xFF5E</span><span class="text">～</span><span class="name">Fullwidth Tilde</li>
-        <li><span class="unicode" role="math">&#xFFE2</span><span class="text">￢</span><span class="name">Fullwidth Not Sign</li>
-        <li><span class="unicode" role="math">&#xFFE9</span><span class="text">￩</span><span class="name">Halfwidth Leftwards Arrow</li>
-        <li><span class="unicode" role="math">&#xFFEA</span><span class="text">￪</span><span class="name">Halfwidth Upwards Arrow</li>
-        <li><span class="unicode" role="math">&#xFFEB</span><span class="text">￫</span><span class="name">Halfwidth Rightwards Arrow</li>
-        <li><span class="unicode" role="math">&#xFFEC</span><span class="text">￬</span><span class="name">Halfwidth Downwards Arrow</li>
-        <li><span class="unicode" role="math">&#x1D6C1</span><span class="text">𝛁</span><span class="name">Mathematical Bold Nabla</li>
-        <li><span class="unicode" role="math">&#x1D6DB</span><span class="text">𝛛</span><span class="name">Mathematical Bold Partial Differential</li>
-        <li><span class="unicode" role="math">&#x1D6FB</span><span class="text">𝛻</span><span class="name">Mathematical Italic Nabla</li>
-        <li><span class="unicode" role="math">&#x1D715</span><span class="text">𝜕</span><span class="name">Mathematical Italic Partial Differential</li>
-        <li><span class="unicode" role="math">&#x1D735</span><span class="text">𝜵</span><span class="name">Mathematical Bold Italic Nabla</li>
-        <li><span class="unicode" role="math">&#x1D74F</span><span class="text">𝝏</span><span class="name">Mathematical Bold Italic Partial Differential</li>
-        <li><span class="unicode" role="math">&#x1D76F</span><span class="text">𝝯</span><span class="name">Mathematical Sans-Serif Bold Nabla</li>
-        <li><span class="unicode" role="math">&#x1D789</span><span class="text">𝞉</span><span class="name">Mathematical Sans-Serif Bold Partial Differential</li>
-        <li><span class="unicode" role="math">&#x1D7A9</span><span class="text">𝞩</span><span class="name">Mathematical Sans-Serif Bold Italic Nabla</li>
-        <li><span class="unicode" role="math">&#x1D7C3</span><span class="text">𝟃</span><span class="name">Mathematical Sans-Serif Bold Italic Partial Differential</li>
-        <li><span class="unicode" role="math">&#x1EEF0</span><span class="text">𞻰</span><span class="name">Arabic Mathematical Operator Meem with Hah with Tatweel</li>
-        <li><span class="unicode" role="math">&#x1EEF1</span><span class="text">𞻱</span><span class="name">Arabic Mathematical Operator Hah with Dal        
+      <li><span class="unicode">&#x002B</span><span class="text">+</span><span class="name">Plus Sign</li>
+        <li><span class="unicode">&#x003C</span><span class="text"><</span><span class="name">Less-Than Sign</li>
+        <li><span class="unicode">&#x003D</span><span class="text">=</span><span class="name">Equals Sign</li>
+        <li><span class="unicode">&#x003E</span><span class="text">></span><span class="name">Greater-Than Sign</li>
+        <li><span class="unicode">&#x007C</span><span class="text">|</span><span class="name">Vertical Line</li>
+        <li><span class="unicode">&#x007E</span><span class="text">~</span><span class="name">Tilde</li>
+        <li><span class="unicode">&#x00AC</span><span class="text">¬</span><span class="name">Not Sign</li>
+        <li><span class="unicode">&#x00B1</span><span class="text">±</span><span class="name">Plus-Minus Sign</li>
+        <li><span class="unicode">&#x00D7</span><span class="text">×</span><span class="name">Multiplication Sign</li>
+        <li><span class="unicode">&#x00F7</span><span class="text">÷</span><span class="name">Division Sign</li>
+        <li><span class="unicode">&#x03F6</span><span class="text">϶</span><span class="name">Greek Reversed Lunate Epsilon Symbol</li>
+        <li><span class="unicode">&#x0606</span><span class="text">؆</span><span class="name">Arabic-Indic Cube Root</li>
+        <li><span class="unicode">&#x0607</span><span class="text">؇</span><span class="name">Arabic-Indic Fourth Root</li>
+        <li><span class="unicode">&#x0608</span><span class="text">؈</span><span class="name">Arabic Ray</li>
+        <li><span class="unicode">&#x2044</span><span class="text">⁄</span><span class="name">Fraction Slash</li>
+        <li><span class="unicode">&#x2052</span><span class="text">⁒</span><span class="name">Commercial Minus Sign</li>
+        <li><span class="unicode">&#x207A</span><span class="text">⁺</span><span class="name">Superscript Plus Sign</li>
+        <li><span class="unicode">&#x207B</span><span class="text">⁻</span><span class="name">Superscript Minus</li>
+        <li><span class="unicode">&#x207C</span><span class="text">⁼</span><span class="name">Superscript Equals Sign</li>
+        <li><span class="unicode">&#x208A</span><span class="text">₊</span><span class="name">Subscript Plus Sign</li>
+        <li><span class="unicode">&#x208B</span><span class="text">₋</span><span class="name">Subscript Minus</li>
+        <li><span class="unicode">&#x208C</span><span class="text">₌</span><span class="name">Subscript Equals Sign</li>
+        <li><span class="unicode">&#x2118</span><span class="text">℘</span><span class="name">Script Capital P</li>
+        <li><span class="unicode">&#x2140</span><span class="text">⅀</span><span class="name">Double-Struck N-Ary Summation</li>
+        <li><span class="unicode">&#x2141</span><span class="text">⅁</span><span class="name">Turned Sans-Serif Capital G</li>
+        <li><span class="unicode">&#x2142</span><span class="text">⅂</span><span class="name">Turned Sans-Serif Capital L</li>
+        <li><span class="unicode">&#x2143</span><span class="text">⅃</span><span class="name">Reversed Sans-Serif Capital L</li>
+        <li><span class="unicode">&#x2144</span><span class="text">⅄</span><span class="name">Turned Sans-Serif Capital Y</li>
+        <li><span class="unicode">&#x214B</span><span class="text">⅋</span><span class="name">Turned Ampersand</li>
+        <li><span class="unicode">&#x2190</span><span class="text">←</span><span class="name">Leftwards Arrow</li>
+        <li><span class="unicode">&#x2191</span><span class="text">↑</span><span class="name">Upwards Arrow</li>
+        <li><span class="unicode">&#x2192</span><span class="text">→</span><span class="name">Rightwards Arrow</li>
+        <li><span class="unicode">&#x2193</span><span class="text">↓</span><span class="name">Downwards Arrow</li>
+        <li><span class="unicode">&#x2194</span><span class="text">↔</span><span class="name">Left Right Arrow</li>
+        <li><span class="unicode">&#x219A</span><span class="text">↚</span><span class="name">Leftwards Arrow with Stroke</li>
+        <li><span class="unicode">&#x219B</span><span class="text">↛</span><span class="name">Rightwards Arrow with Stroke</li>
+        <li><span class="unicode">&#x21A0</span><span class="text">↠</span><span class="name">Rightwards Two Headed Arrow</li>
+        <li><span class="unicode">&#x21A3</span><span class="text">↣</span><span class="name">Rightwards Arrow with Tail</li>
+        <li><span class="unicode">&#x21A6</span><span class="text">↦</span><span class="name">Rightwards Arrow from Bar</li>
+        <li><span class="unicode">&#x21AE</span><span class="text">↮</span><span class="name">Left Right Arrow with Stroke</li>
+        <li><span class="unicode">&#x21CE</span><span class="text">⇎</span><span class="name">Left Right Double Arrow with Stroke</li>
+        <li><span class="unicode">&#x21CF</span><span class="text">⇏</span><span class="name">Rightwards Double Arrow with Stroke</li>
+        <li><span class="unicode">&#x21D2</span><span class="text">⇒</span><span class="name">Rightwards Double Arrow</li>
+        <li><span class="unicode">&#x21D4</span><span class="text">⇔</span><span class="name">Left Right Double Arrow</li>
+        <li><span class="unicode">&#x21F4</span><span class="text">⇴</span><span class="name">Right Arrow with Small Circle</li>
+        <li><span class="unicode">&#x21F5</span><span class="text">⇵</span><span class="name">Downwards Arrow Leftwards of Upwards Arrow</li>
+        <li><span class="unicode">&#x21F6</span><span class="text">⇶</span><span class="name">Three Rightwards Arrows</li>
+        <li><span class="unicode">&#x21F7</span><span class="text">⇷</span><span class="name">Leftwards Arrow with Vertical Stroke</li>
+        <li><span class="unicode">&#x21F8</span><span class="text">⇸</span><span class="name">Rightwards Arrow with Vertical Stroke</li>
+        <li><span class="unicode">&#x21F9</span><span class="text">⇹</span><span class="name">Left Right Arrow with Vertical Stroke</li>
+        <li><span class="unicode">&#x21FA</span><span class="text">⇺</span><span class="name">Leftwards Arrow with Double Vertical Stroke</li>
+        <li><span class="unicode">&#x21FB</span><span class="text">⇻</span><span class="name">Rightwards Arrow with Double Vertical Stroke</li>
+        <li><span class="unicode">&#x21FC</span><span class="text">⇼</span><span class="name">Left Right Arrow with Double Vertical Stroke</li>
+        <li><span class="unicode">&#x21FD</span><span class="text">⇽</span><span class="name">Leftwards Open-Headed Arrow</li>
+        <li><span class="unicode">&#x21FE</span><span class="text">⇾</span><span class="name">Rightwards Open-Headed Arrow</li>
+        <li><span class="unicode">&#x21FF</span><span class="text">⇿</span><span class="name">Left Right Open-Headed Arrow</li>
+        <li><span class="unicode">&#x2200</span><span class="text">∀</span><span class="name">For All</li>
+        <li><span class="unicode">&#x2201</span><span class="text">∁</span><span class="name">Complement</li>
+        <li><span class="unicode">&#x2202</span><span class="text">∂</span><span class="name">Partial Differential</li>
+        <li><span class="unicode">&#x2203</span><span class="text">∃</span><span class="name">There Exists</li>
+        <li><span class="unicode">&#x2204</span><span class="text">∄</span><span class="name">There Does Not Exist</li>
+        <li><span class="unicode">&#x2205</span><span class="text">∅</span><span class="name">Empty Set</li>
+        <li><span class="unicode">&#x2206</span><span class="text">∆</span><span class="name">Increment</li>
+        <li><span class="unicode">&#x2207</span><span class="text">∇</span><span class="name">Nabla</li>
+        <li><span class="unicode">&#x2208</span><span class="text">∈</span><span class="name">Element Of</li>
+        <li><span class="unicode">&#x2209</span><span class="text">∉</span><span class="name">Not An Element Of</li>
+        <li><span class="unicode">&#x220A</span><span class="text">∊</span><span class="name">Small Element Of</li>
+        <li><span class="unicode">&#x220B</span><span class="text">∋</span><span class="name">Contains as Member</li>
+        <li><span class="unicode">&#x220C</span><span class="text">∌</span><span class="name">Does Not Contain as Member</li>
+        <li><span class="unicode">&#x220D</span><span class="text">∍</span><span class="name">Small Contains as Member</li>
+        <li><span class="unicode">&#x220E</span><span class="text">∎</span><span class="name">End of Proof</li>
+        <li><span class="unicode">&#x220F</span><span class="text">∏</span><span class="name">N-Ary Product</li>
+        <li><span class="unicode">&#x2210</span><span class="text">∐</span><span class="name">N-Ary Coproduct</li>
+        <li><span class="unicode">&#x2211</span><span class="text">∑</span><span class="name">N-Ary Summation</li>
+        <li><span class="unicode">&#x2212</span><span class="text">−</span><span class="name">Minus Sign</li>
+        <li><span class="unicode">&#x2213</span><span class="text">∓</span><span class="name">Minus-or-Plus Sign</li>
+        <li><span class="unicode">&#x2214</span><span class="text">∔</span><span class="name">Dot Plus</li>
+        <li><span class="unicode">&#x2215</span><span class="text">∕</span><span class="name">Division Slash</li>
+        <li><span class="unicode">&#x2216</span><span class="text">∖</span><span class="name">Set Minus</li>
+        <li><span class="unicode">&#x2217</span><span class="text">∗</span><span class="name">Asterisk Operator</li>
+        <li><span class="unicode">&#x2218</span><span class="text">∘</span><span class="name">Ring Operator</li>
+        <li><span class="unicode">&#x2219</span><span class="text">∙</span><span class="name">Bullet Operator</li>
+        <li><span class="unicode">&#x221A</span><span class="text">√</span><span class="name">Square Root</li>
+        <li><span class="unicode">&#x221B</span><span class="text">∛</span><span class="name">Cube Root</li>
+        <li><span class="unicode">&#x221C</span><span class="text">∜</span><span class="name">Fourth Root</li>
+        <li><span class="unicode">&#x221D</span><span class="text">∝</span><span class="name">Proportional To</li>
+        <li><span class="unicode">&#x221E</span><span class="text">∞</span><span class="name">Infinity</li>
+        <li><span class="unicode">&#x221F</span><span class="text">∟</span><span class="name">Right Angle</li>
+        <li><span class="unicode">&#x2220</span><span class="text">∠</span><span class="name">Angle</li>
+        <li><span class="unicode">&#x2221</span><span class="text">∡</span><span class="name">Measured Angle</li>
+        <li><span class="unicode">&#x2222</span><span class="text">∢</span><span class="name">Spherical Angle</li>
+        <li><span class="unicode">&#x2223</span><span class="text">∣</span><span class="name">Divides</li>
+        <li><span class="unicode">&#x2224</span><span class="text">∤</span><span class="name">Does Not Divide</li>
+        <li><span class="unicode">&#x2225</span><span class="text">∥</span><span class="name">Parallel To</li>
+        <li><span class="unicode">&#x2226</span><span class="text">∦</span><span class="name">Not Parallel To</li>
+        <li><span class="unicode">&#x2227</span><span class="text">∧</span><span class="name">Logical And</li>
+        <li><span class="unicode">&#x2228</span><span class="text">∨</span><span class="name">Logical Or</li>
+        <li><span class="unicode">&#x2229</span><span class="text">∩</span><span class="name">Intersection</li>
+        <li><span class="unicode">&#x222A</span><span class="text">∪</span><span class="name">Union</li>
+        <li><span class="unicode">&#x222B</span><span class="text">∫</span><span class="name">Integral</li>
+        <li><span class="unicode">&#x222C</span><span class="text">∬</span><span class="name">Double Integral</li>
+        <li><span class="unicode">&#x222D</span><span class="text">∭</span><span class="name">Triple Integral</li>
+        <li><span class="unicode">&#x222E</span><span class="text">∮</span><span class="name">Contour Integral</li>
+        <li><span class="unicode">&#x222F</span><span class="text">∯</span><span class="name">Surface Integral</li>
+        <li><span class="unicode">&#x2230</span><span class="text">∰</span><span class="name">Volume Integral</li>
+        <li><span class="unicode">&#x2231</span><span class="text">∱</span><span class="name">Clockwise Integral</li>
+        <li><span class="unicode">&#x2232</span><span class="text">∲</span><span class="name">Clockwise Contour Integral</li>
+        <li><span class="unicode">&#x2233</span><span class="text">∳</span><span class="name">Anticlockwise Contour Integral</li>
+        <li><span class="unicode">&#x2234</span><span class="text">∴</span><span class="name">Therefore</li>
+        <li><span class="unicode">&#x2235</span><span class="text">∵</span><span class="name">Because</li>
+        <li><span class="unicode">&#x2236</span><span class="text">∶</span><span class="name">Ratio</li>
+        <li><span class="unicode">&#x2237</span><span class="text">∷</span><span class="name">Proportion</li>
+        <li><span class="unicode">&#x2238</span><span class="text">∸</span><span class="name">Dot Minus</li>
+        <li><span class="unicode">&#x2239</span><span class="text">∹</span><span class="name">Excess</li>
+        <li><span class="unicode">&#x223A</span><span class="text">∺</span><span class="name">Geometric Proportion</li>
+        <li><span class="unicode">&#x223B</span><span class="text">∻</span><span class="name">Homothetic</li>
+        <li><span class="unicode">&#x223C</span><span class="text">∼</span><span class="name">Tilde Operator</li>
+        <li><span class="unicode">&#x223D</span><span class="text">∽</span><span class="name">Reversed Tilde</li>
+        <li><span class="unicode">&#x223E</span><span class="text">∾</span><span class="name">Inverted Lazy S</li>
+        <li><span class="unicode">&#x223F</span><span class="text">∿</span><span class="name">Sine Wave</li>
+        <li><span class="unicode">&#x2240</span><span class="text">≀</span><span class="name">Wreath Product</li>
+        <li><span class="unicode">&#x2241</span><span class="text">≁</span><span class="name">Not Tilde</li>
+        <li><span class="unicode">&#x2242</span><span class="text">≂</span><span class="name">Minus Tilde</li>
+        <li><span class="unicode">&#x2243</span><span class="text">≃</span><span class="name">Asymptotically Equal To</li>
+        <li><span class="unicode">&#x2244</span><span class="text">≄</span><span class="name">Not Asymptotically Equal To</li>
+        <li><span class="unicode">&#x2245</span><span class="text">≅</span><span class="name">Approximately Equal To</li>
+        <li><span class="unicode">&#x2246</span><span class="text">≆</span><span class="name">Approximately But Not Actually Equal To</li>
+        <li><span class="unicode">&#x2247</span><span class="text">≇</span><span class="name">Neither Approximately Nor Actually Equal To</li>
+        <li><span class="unicode">&#x2248</span><span class="text">≈</span><span class="name">Almost Equal To</li>
+        <li><span class="unicode">&#x2249</span><span class="text">≉</span><span class="name">Not Almost Equal To</li>
+        <li><span class="unicode">&#x224A</span><span class="text">≊</span><span class="name">Almost Equal or Equal To</li>
+        <li><span class="unicode">&#x224B</span><span class="text">≋</span><span class="name">Triple Tilde</li>
+        <li><span class="unicode">&#x224C</span><span class="text">≌</span><span class="name">All Equal To</li>
+        <li><span class="unicode">&#x224D</span><span class="text">≍</span><span class="name">Equivalent To</li>
+        <li><span class="unicode">&#x224E</span><span class="text">≎</span><span class="name">Geometrically Equivalent To</li>
+        <li><span class="unicode">&#x224F</span><span class="text">≏</span><span class="name">Difference Between</li>
+        <li><span class="unicode">&#x2250</span><span class="text">≐</span><span class="name">Approaches the Limit</li>
+        <li><span class="unicode">&#x2251</span><span class="text">≑</span><span class="name">Geometrically Equal To</li>
+        <li><span class="unicode">&#x2252</span><span class="text">≒</span><span class="name">Approximately Equal to or the Image Of</li>
+        <li><span class="unicode">&#x2253</span><span class="text">≓</span><span class="name">Image of or Approximately Equal To</li>
+        <li><span class="unicode">&#x2254</span><span class="text">≔</span><span class="name">Colon Equals</li>
+        <li><span class="unicode">&#x2255</span><span class="text">≕</span><span class="name">Equals Colon</li>
+        <li><span class="unicode">&#x2256</span><span class="text">≖</span><span class="name">Ring In Equal To</li>
+        <li><span class="unicode">&#x2257</span><span class="text">≗</span><span class="name">Ring Equal To</li>
+        <li><span class="unicode">&#x2258</span><span class="text">≘</span><span class="name">Corresponds To</li>
+        <li><span class="unicode">&#x2259</span><span class="text">≙</span><span class="name">Estimates</li>
+        <li><span class="unicode">&#x225A</span><span class="text">≚</span><span class="name">Equiangular To</li>
+        <li><span class="unicode">&#x225B</span><span class="text">≛</span><span class="name">Star Equals</li>
+        <li><span class="unicode">&#x225C</span><span class="text">≜</span><span class="name">Delta Equal To</li>
+        <li><span class="unicode">&#x225D</span><span class="text">≝</span><span class="name">Equal to By Definition</li>
+        <li><span class="unicode">&#x225E</span><span class="text">≞</span><span class="name">Measured By</li>
+        <li><span class="unicode">&#x225F</span><span class="text">≟</span><span class="name">Questioned Equal To</li>
+        <li><span class="unicode">&#x2260</span><span class="text">≠</span><span class="name">Not Equal To</li>
+        <li><span class="unicode">&#x2261</span><span class="text">≡</span><span class="name">Identical To</li>
+        <li><span class="unicode">&#x2262</span><span class="text">≢</span><span class="name">Not Identical To</li>
+        <li><span class="unicode">&#x2263</span><span class="text">≣</span><span class="name">Strictly Equivalent To</li>
+        <li><span class="unicode">&#x2264</span><span class="text">≤</span><span class="name">Less-Than or Equal To</li>
+        <li><span class="unicode">&#x2265</span><span class="text">≥</span><span class="name">Greater-Than or Equal To</li>
+        <li><span class="unicode">&#x2266</span><span class="text">≦</span><span class="name">Less-Than Over Equal To</li>
+        <li><span class="unicode">&#x2267</span><span class="text">≧</span><span class="name">Greater-Than Over Equal To</li>
+        <li><span class="unicode">&#x2268</span><span class="text">≨</span><span class="name">Less-Than But Not Equal To</li>
+        <li><span class="unicode">&#x2269</span><span class="text">≩</span><span class="name">Greater-Than But Not Equal To</li>
+        <li><span class="unicode">&#x226A</span><span class="text">≪</span><span class="name">Much Less-Than</li>
+        <li><span class="unicode">&#x226B</span><span class="text">≫</span><span class="name">Much Greater-Than</li>
+        <li><span class="unicode">&#x226C</span><span class="text">≬</span><span class="name">Between</li>
+        <li><span class="unicode">&#x226D</span><span class="text">≭</span><span class="name">Not Equivalent To</li>
+        <li><span class="unicode">&#x226E</span><span class="text">≮</span><span class="name">Not Less-Than</li>
+        <li><span class="unicode">&#x226F</span><span class="text">≯</span><span class="name">Not Greater-Than</li>
+        <li><span class="unicode">&#x2270</span><span class="text">≰</span><span class="name">Neither Less-Than Nor Equal To</li>
+        <li><span class="unicode">&#x2271</span><span class="text">≱</span><span class="name">Neither Greater-Than Nor Equal To</li>
+        <li><span class="unicode">&#x2272</span><span class="text">≲</span><span class="name">Less-Than or Equivalent To</li>
+        <li><span class="unicode">&#x2273</span><span class="text">≳</span><span class="name">Greater-Than or Equivalent To</li>
+        <li><span class="unicode">&#x2274</span><span class="text">≴</span><span class="name">Neither Less-Than Nor Equivalent To</li>
+        <li><span class="unicode">&#x2275</span><span class="text">≵</span><span class="name">Neither Greater-Than Nor Equivalent To</li>
+        <li><span class="unicode">&#x2276</span><span class="text">≶</span><span class="name">Less-Than or Greater-Than</li>
+        <li><span class="unicode">&#x2277</span><span class="text">≷</span><span class="name">Greater-Than or Less-Than</li>
+        <li><span class="unicode">&#x2278</span><span class="text">≸</span><span class="name">Neither Less-Than Nor Greater-Than</li>
+        <li><span class="unicode">&#x2279</span><span class="text">≹</span><span class="name">Neither Greater-Than Nor Less-Than</li>
+        <li><span class="unicode">&#x227A</span><span class="text">≺</span><span class="name">Precedes</li>
+        <li><span class="unicode">&#x227B</span><span class="text">≻</span><span class="name">Succeeds</li>
+        <li><span class="unicode">&#x227C</span><span class="text">≼</span><span class="name">Precedes or Equal To</li>
+        <li><span class="unicode">&#x227D</span><span class="text">≽</span><span class="name">Succeeds or Equal To</li>
+        <li><span class="unicode">&#x227E</span><span class="text">≾</span><span class="name">Precedes or Equivalent To</li>
+        <li><span class="unicode">&#x227F</span><span class="text">≿</span><span class="name">Succeeds or Equivalent To</li>
+        <li><span class="unicode">&#x2280</span><span class="text">⊀</span><span class="name">Does Not Precede</li>
+        <li><span class="unicode">&#x2281</span><span class="text">⊁</span><span class="name">Does Not Succeed</li>
+        <li><span class="unicode">&#x2282</span><span class="text">⊂</span><span class="name">Subset Of</li>
+        <li><span class="unicode">&#x2283</span><span class="text">⊃</span><span class="name">Superset Of</li>
+        <li><span class="unicode">&#x2284</span><span class="text">⊄</span><span class="name">Not A Subset Of</li>
+        <li><span class="unicode">&#x2285</span><span class="text">⊅</span><span class="name">Not A Superset Of</li>
+        <li><span class="unicode">&#x2286</span><span class="text">⊆</span><span class="name">Subset of or Equal To</li>
+        <li><span class="unicode">&#x2287</span><span class="text">⊇</span><span class="name">Superset of or Equal To</li>
+        <li><span class="unicode">&#x2288</span><span class="text">⊈</span><span class="name">Neither A Subset of Nor Equal To</li>
+        <li><span class="unicode">&#x2289</span><span class="text">⊉</span><span class="name">Neither A Superset of Nor Equal To</li>
+        <li><span class="unicode">&#x228A</span><span class="text">⊊</span><span class="name">Subset of with Not Equal To</li>
+        <li><span class="unicode">&#x228B</span><span class="text">⊋</span><span class="name">Superset of with Not Equal To</li>
+        <li><span class="unicode">&#x228C</span><span class="text">⊌</span><span class="name">Multiset</li>
+        <li><span class="unicode">&#x228D</span><span class="text">⊍</span><span class="name">Multiset Multiplication</li>
+        <li><span class="unicode">&#x228E</span><span class="text">⊎</span><span class="name">Multiset Union</li>
+        <li><span class="unicode">&#x228F</span><span class="text">⊏</span><span class="name">Square Image Of</li>
+        <li><span class="unicode">&#x2290</span><span class="text">⊐</span><span class="name">Square Original Of</li>
+        <li><span class="unicode">&#x2291</span><span class="text">⊑</span><span class="name">Square Image of or Equal To</li>
+        <li><span class="unicode">&#x2292</span><span class="text">⊒</span><span class="name">Square Original of or Equal To</li>
+        <li><span class="unicode">&#x2293</span><span class="text">⊓</span><span class="name">Square Cap</li>
+        <li><span class="unicode">&#x2294</span><span class="text">⊔</span><span class="name">Square Cup</li>
+        <li><span class="unicode">&#x2295</span><span class="text">⊕</span><span class="name">Circled Plus</li>
+        <li><span class="unicode">&#x2296</span><span class="text">⊖</span><span class="name">Circled Minus</li>
+        <li><span class="unicode">&#x2297</span><span class="text">⊗</span><span class="name">Circled Times</li>
+        <li><span class="unicode">&#x2298</span><span class="text">⊘</span><span class="name">Circled Division Slash</li>
+        <li><span class="unicode">&#x2299</span><span class="text">⊙</span><span class="name">Circled Dot Operator</li>
+        <li><span class="unicode">&#x229A</span><span class="text">⊚</span><span class="name">Circled Ring Operator</li>
+        <li><span class="unicode">&#x229B</span><span class="text">⊛</span><span class="name">Circled Asterisk Operator</li>
+        <li><span class="unicode">&#x229C</span><span class="text">⊜</span><span class="name">Circled Equals</li>
+        <li><span class="unicode">&#x229D</span><span class="text">⊝</span><span class="name">Circled Dash</li>
+        <li><span class="unicode">&#x229E</span><span class="text">⊞</span><span class="name">Squared Plus</li>
+        <li><span class="unicode">&#x229F</span><span class="text">⊟</span><span class="name">Squared Minus</li>
+        <li><span class="unicode">&#x22A0</span><span class="text">⊠</span><span class="name">Squared Times</li>
+        <li><span class="unicode">&#x22A1</span><span class="text">⊡</span><span class="name">Squared Dot Operator</li>
+        <li><span class="unicode">&#x22A2</span><span class="text">⊢</span><span class="name">Right Tack</li>
+        <li><span class="unicode">&#x22A3</span><span class="text">⊣</span><span class="name">Left Tack</li>
+        <li><span class="unicode">&#x22A4</span><span class="text">⊤</span><span class="name">Down Tack</li>
+        <li><span class="unicode">&#x22A5</span><span class="text">⊥</span><span class="name">Up Tack</li>
+        <li><span class="unicode">&#x22A6</span><span class="text">⊦</span><span class="name">Assertion</li>
+        <li><span class="unicode">&#x22A7</span><span class="text">⊧</span><span class="name">Models</li>
+        <li><span class="unicode">&#x22A8</span><span class="text">⊨</span><span class="name">True</li>
+        <li><span class="unicode">&#x22A9</span><span class="text">⊩</span><span class="name">Forces</li>
+        <li><span class="unicode">&#x22AA</span><span class="text">⊪</span><span class="name">Triple Vertical Bar Right Turnstile</li>
+        <li><span class="unicode">&#x22AB</span><span class="text">⊫</span><span class="name">Double Vertical Bar Double Right Turnstile</li>
+        <li><span class="unicode">&#x22AC</span><span class="text">⊬</span><span class="name">Does Not Prove</li>
+        <li><span class="unicode">&#x22AD</span><span class="text">⊭</span><span class="name">Not True</li>
+        <li><span class="unicode">&#x22AE</span><span class="text">⊮</span><span class="name">Does Not Force</li>
+        <li><span class="unicode">&#x22AF</span><span class="text">⊯</span><span class="name">Negated Double Vertical Bar Double Right Turnstile</li>
+        <li><span class="unicode">&#x22B0</span><span class="text">⊰</span><span class="name">Precedes Under Relation</li>
+        <li><span class="unicode">&#x22B1</span><span class="text">⊱</span><span class="name">Succeeds Under Relation</li>
+        <li><span class="unicode">&#x22B2</span><span class="text">⊲</span><span class="name">Normal Subgroup Of</li>
+        <li><span class="unicode">&#x22B3</span><span class="text">⊳</span><span class="name">Contains as Normal Subgroup</li>
+        <li><span class="unicode">&#x22B4</span><span class="text">⊴</span><span class="name">Normal Subgroup of or Equal To</li>
+        <li><span class="unicode">&#x22B5</span><span class="text">⊵</span><span class="name">Contains as Normal Subgroup or Equal To</li>
+        <li><span class="unicode">&#x22B6</span><span class="text">⊶</span><span class="name">Original Of</li>
+        <li><span class="unicode">&#x22B7</span><span class="text">⊷</span><span class="name">Image Of</li>
+        <li><span class="unicode">&#x22B8</span><span class="text">⊸</span><span class="name">Multimap</li>
+        <li><span class="unicode">&#x22B9</span><span class="text">⊹</span><span class="name">Hermitian Conjugate Matrix</li>
+        <li><span class="unicode">&#x22BA</span><span class="text">⊺</span><span class="name">Intercalate</li>
+        <li><span class="unicode">&#x22BB</span><span class="text">⊻</span><span class="name">Xor</li>
+        <li><span class="unicode">&#x22BC</span><span class="text">⊼</span><span class="name">Nand</li>
+        <li><span class="unicode">&#x22BD</span><span class="text">⊽</span><span class="name">Nor</li>
+        <li><span class="unicode">&#x22BE</span><span class="text">⊾</span><span class="name">Right Angle with Arc</li>
+        <li><span class="unicode">&#x22BF</span><span class="text">⊿</span><span class="name">Right Triangle</li>
+        <li><span class="unicode">&#x22C0</span><span class="text">⋀</span><span class="name">N-Ary Logical And</li>
+        <li><span class="unicode">&#x22C1</span><span class="text">⋁</span><span class="name">N-Ary Logical Or</li>
+        <li><span class="unicode">&#x22C2</span><span class="text">⋂</span><span class="name">N-Ary Intersection</li>
+        <li><span class="unicode">&#x22C3</span><span class="text">⋃</span><span class="name">N-Ary Union</li>
+        <li><span class="unicode">&#x22C4</span><span class="text">⋄</span><span class="name">Diamond Operator</li>
+        <li><span class="unicode">&#x22C5</span><span class="text">⋅</span><span class="name">Dot Operator</li>
+        <li><span class="unicode">&#x22C6</span><span class="text">⋆</span><span class="name">Star Operator</li>
+        <li><span class="unicode">&#x22C7</span><span class="text">⋇</span><span class="name">Division Times</li>
+        <li><span class="unicode">&#x22C8</span><span class="text">⋈</span><span class="name">Bowtie</li>
+        <li><span class="unicode">&#x22C9</span><span class="text">⋉</span><span class="name">Left Normal Factor Semidirect Product</li>
+        <li><span class="unicode">&#x22CA</span><span class="text">⋊</span><span class="name">Right Normal Factor Semidirect Product</li>
+        <li><span class="unicode">&#x22CB</span><span class="text">⋋</span><span class="name">Left Semidirect Product</li>
+        <li><span class="unicode">&#x22CC</span><span class="text">⋌</span><span class="name">Right Semidirect Product</li>
+        <li><span class="unicode">&#x22CD</span><span class="text">⋍</span><span class="name">Reversed Tilde Equals</li>
+        <li><span class="unicode">&#x22CE</span><span class="text">⋎</span><span class="name">Curly Logical Or</li>
+        <li><span class="unicode">&#x22CF</span><span class="text">⋏</span><span class="name">Curly Logical And</li>
+        <li><span class="unicode">&#x22D0</span><span class="text">⋐</span><span class="name">Double Subset</li>
+        <li><span class="unicode">&#x22D1</span><span class="text">⋑</span><span class="name">Double Superset</li>
+        <li><span class="unicode">&#x22D2</span><span class="text">⋒</span><span class="name">Double Intersection</li>
+        <li><span class="unicode">&#x22D3</span><span class="text">⋓</span><span class="name">Double Union</li>
+        <li><span class="unicode">&#x22D4</span><span class="text">⋔</span><span class="name">Pitchfork</li>
+        <li><span class="unicode">&#x22D5</span><span class="text">⋕</span><span class="name">Equal and Parallel To</li>
+        <li><span class="unicode">&#x22D6</span><span class="text">⋖</span><span class="name">Less-Than with Dot</li>
+        <li><span class="unicode">&#x22D7</span><span class="text">⋗</span><span class="name">Greater-Than with Dot</li>
+        <li><span class="unicode">&#x22D8</span><span class="text">⋘</span><span class="name">Very Much Less-Than</li>
+        <li><span class="unicode">&#x22D9</span><span class="text">⋙</span><span class="name">Very Much Greater-Than</li>
+        <li><span class="unicode">&#x22DA</span><span class="text">⋚</span><span class="name">Less-Than Equal to or Greater-Than</li>
+        <li><span class="unicode">&#x22DB</span><span class="text">⋛</span><span class="name">Greater-Than Equal to or Less-Than</li>
+        <li><span class="unicode">&#x22DC</span><span class="text">⋜</span><span class="name">Equal to or Less-Than</li>
+        <li><span class="unicode">&#x22DD</span><span class="text">⋝</span><span class="name">Equal to or Greater-Than</li>
+        <li><span class="unicode">&#x22DE</span><span class="text">⋞</span><span class="name">Equal to or Precedes</li>
+        <li><span class="unicode">&#x22DF</span><span class="text">⋟</span><span class="name">Equal to or Succeeds</li>
+        <li><span class="unicode">&#x22E0</span><span class="text">⋠</span><span class="name">Does Not Precede or Equal</li>
+        <li><span class="unicode">&#x22E1</span><span class="text">⋡</span><span class="name">Does Not Succeed or Equal</li>
+        <li><span class="unicode">&#x22E2</span><span class="text">⋢</span><span class="name">Not Square Image of or Equal To</li>
+        <li><span class="unicode">&#x22E3</span><span class="text">⋣</span><span class="name">Not Square Original of or Equal To</li>
+        <li><span class="unicode">&#x22E4</span><span class="text">⋤</span><span class="name">Square Image of or Not Equal To</li>
+        <li><span class="unicode">&#x22E5</span><span class="text">⋥</span><span class="name">Square Original of or Not Equal To</li>
+        <li><span class="unicode">&#x22E6</span><span class="text">⋦</span><span class="name">Less-Than But Not Equivalent To</li>
+        <li><span class="unicode">&#x22E7</span><span class="text">⋧</span><span class="name">Greater-Than But Not Equivalent To</li>
+        <li><span class="unicode">&#x22E8</span><span class="text">⋨</span><span class="name">Precedes But Not Equivalent To</li>
+        <li><span class="unicode">&#x22E9</span><span class="text">⋩</span><span class="name">Succeeds But Not Equivalent To</li>
+        <li><span class="unicode">&#x22EA</span><span class="text">⋪</span><span class="name">Not Normal Subgroup Of</li>
+        <li><span class="unicode">&#x22EB</span><span class="text">⋫</span><span class="name">Does Not Contain as Normal Subgroup</li>
+        <li><span class="unicode">&#x22EC</span><span class="text">⋬</span><span class="name">Not Normal Subgroup of or Equal To</li>
+        <li><span class="unicode">&#x22ED</span><span class="text">⋭</span><span class="name">Does Not Contain as Normal Subgroup or Equal</li>
+        <li><span class="unicode">&#x22EE</span><span class="text">⋮</span><span class="name">Vertical Ellipsis</li>
+        <li><span class="unicode">&#x22EF</span><span class="text">⋯</span><span class="name">Midline Horizontal Ellipsis</li>
+        <li><span class="unicode">&#x22F0</span><span class="text">⋰</span><span class="name">Up Right Diagonal Ellipsis</li>
+        <li><span class="unicode">&#x22F1</span><span class="text">⋱</span><span class="name">Down Right Diagonal Ellipsis</li>
+        <li><span class="unicode">&#x22F2</span><span class="text">⋲</span><span class="name">Element of with Long Horizontal Stroke</li>
+        <li><span class="unicode">&#x22F3</span><span class="text">⋳</span><span class="name">Element of with Vertical Bar at End of Horizontal Stroke</li>
+        <li><span class="unicode">&#x22F4</span><span class="text">⋴</span><span class="name">Small Element of with Vertical Bar at End of Horizontal Stroke</li>
+        <li><span class="unicode">&#x22F5</span><span class="text">⋵</span><span class="name">Element of with Dot Above</li>
+        <li><span class="unicode">&#x22F6</span><span class="text">⋶</span><span class="name">Element of with Overbar</li>
+        <li><span class="unicode">&#x22F7</span><span class="text">⋷</span><span class="name">Small Element of with Overbar</li>
+        <li><span class="unicode">&#x22F8</span><span class="text">⋸</span><span class="name">Element of with Underbar</li>
+        <li><span class="unicode">&#x22F9</span><span class="text">⋹</span><span class="name">Element of with Two Horizontal Strokes</li>
+        <li><span class="unicode">&#x22FA</span><span class="text">⋺</span><span class="name">Contains with Long Horizontal Stroke</li>
+        <li><span class="unicode">&#x22FB</span><span class="text">⋻</span><span class="name">Contains with Vertical Bar at End of Horizontal Stroke</li>
+        <li><span class="unicode">&#x22FC</span><span class="text">⋼</span><span class="name">Small Contains with Vertical Bar at End of Horizontal Stroke</li>
+        <li><span class="unicode">&#x22FD</span><span class="text">⋽</span><span class="name">Contains with Overbar</li>
+        <li><span class="unicode">&#x22FE</span><span class="text">⋾</span><span class="name">Small Contains with Overbar</li>
+        <li><span class="unicode">&#x22FF</span><span class="text">⋿</span><span class="name">Z Notation Bag Membership</li>
+        <li><span class="unicode">&#x2320</span><span class="text">⌠</span><span class="name">Top Half Integral</li>
+        <li><span class="unicode">&#x2321</span><span class="text">⌡</span><span class="name">Bottom Half Integral</li>
+        <li><span class="unicode">&#x237C</span><span class="text">⍼</span><span class="name">Right Angle with Downwards Zigzag Arrow</li>
+        <li><span class="unicode">&#x239B</span><span class="text">⎛</span><span class="name">Left Parenthesis Upper Hook</li>
+        <li><span class="unicode">&#x239C</span><span class="text">⎜</span><span class="name">Left Parenthesis Extension</li>
+        <li><span class="unicode">&#x239D</span><span class="text">⎝</span><span class="name">Left Parenthesis Lower Hook</li>
+        <li><span class="unicode">&#x239E</span><span class="text">⎞</span><span class="name">Right Parenthesis Upper Hook</li>
+        <li><span class="unicode">&#x239F</span><span class="text">⎟</span><span class="name">Right Parenthesis Extension</li>
+        <li><span class="unicode">&#x23A0</span><span class="text">⎠</span><span class="name">Right Parenthesis Lower Hook</li>
+        <li><span class="unicode">&#x23A1</span><span class="text">⎡</span><span class="name">Left Square Bracket Upper Corner</li>
+        <li><span class="unicode">&#x23A2</span><span class="text">⎢</span><span class="name">Left Square Bracket Extension</li>
+        <li><span class="unicode">&#x23A3</span><span class="text">⎣</span><span class="name">Left Square Bracket Lower Corner</li>
+        <li><span class="unicode">&#x23A4</span><span class="text">⎤</span><span class="name">Right Square Bracket Upper Corner</li>
+        <li><span class="unicode">&#x23A5</span><span class="text">⎥</span><span class="name">Right Square Bracket Extension</li>
+        <li><span class="unicode">&#x23A6</span><span class="text">⎦</span><span class="name">Right Square Bracket Lower Corner</li>
+        <li><span class="unicode">&#x23A7</span><span class="text">⎧</span><span class="name">Left Curly Bracket Upper Hook</li>
+        <li><span class="unicode">&#x23A8</span><span class="text">⎨</span><span class="name">Left Curly Bracket Middle Piece</li>
+        <li><span class="unicode">&#x23A9</span><span class="text">⎩</span><span class="name">Left Curly Bracket Lower Hook</li>
+        <li><span class="unicode">&#x23AA</span><span class="text">⎪</span><span class="name">Curly Bracket Extension</li>
+        <li><span class="unicode">&#x23AB</span><span class="text">⎫</span><span class="name">Right Curly Bracket Upper Hook</li>
+        <li><span class="unicode">&#x23AC</span><span class="text">⎬</span><span class="name">Right Curly Bracket Middle Piece</li>
+        <li><span class="unicode">&#x23AD</span><span class="text">⎭</span><span class="name">Right Curly Bracket Lower Hook</li>
+        <li><span class="unicode">&#x23AE</span><span class="text">⎮</span><span class="name">Integral Extension</li>
+        <li><span class="unicode">&#x23AF</span><span class="text">⎯</span><span class="name">Horizontal Line Extension</li>
+        <li><span class="unicode">&#x23B0</span><span class="text">⎰</span><span class="name">Upper Left or Lower Right Curly Bracket Section</li>
+        <li><span class="unicode">&#x23B1</span><span class="text">⎱</span><span class="name">Upper Right or Lower Left Curly Bracket Section</li>
+        <li><span class="unicode">&#x23B2</span><span class="text">⎲</span><span class="name">Summation Top</li>
+        <li><span class="unicode">&#x23B3</span><span class="text">⎳</span><span class="name">Summation Bottom</li>
+        <li><span class="unicode">&#x23DC</span><span class="text">⏜</span><span class="name">Top Parenthesis</li>
+        <li><span class="unicode">&#x23DD</span><span class="text">⏝</span><span class="name">Bottom Parenthesis</li>
+        <li><span class="unicode">&#x23DE</span><span class="text">⏞</span><span class="name">Top Curly Bracket</li>
+        <li><span class="unicode">&#x23DF</span><span class="text">⏟</span><span class="name">Bottom Curly Bracket</li>
+        <li><span class="unicode">&#x23E0</span><span class="text">⏠</span><span class="name">Top Tortoise Shell Bracket</li>
+        <li><span class="unicode">&#x23E1</span><span class="text">⏡</span><span class="name">Bottom Tortoise Shell Bracket</li>
+        <li><span class="unicode">&#x25B7</span><span class="text">▷</span><span class="name">White Right-Pointing Triangle</li>
+        <li><span class="unicode">&#x25C1</span><span class="text">◁</span><span class="name">White Left-Pointing Triangle</li>
+        <li><span class="unicode">&#x25F8</span><span class="text">◸</span><span class="name">Upper Left Triangle</li>
+        <li><span class="unicode">&#x25F9</span><span class="text">◹</span><span class="name">Upper Right Triangle</li>
+        <li><span class="unicode">&#x25FA</span><span class="text">◺</span><span class="name">Lower Left Triangle</li>
+        <li><span class="unicode">&#x25FB</span><span class="text">◻</span><span class="name">White Medium Square</li>
+        <li><span class="unicode">&#x25FC</span><span class="text">◼</span><span class="name">Black Medium Square</li>
+        <li><span class="unicode">&#x25FD</span><span class="text">◽</span><span class="name">White Medium Small Square</li>
+        <li><span class="unicode">&#x25FE</span><span class="text">◾</span><span class="name">Black Medium Small Square</li>
+        <li><span class="unicode">&#x25FF</span><span class="text">◿</span><span class="name">Lower Right Triangle</li>
+        <li><span class="unicode">&#x266F</span><span class="text">♯</span><span class="name">Music Sharp Sign</li>
+        <li><span class="unicode">&#x27C0</span><span class="text">⟀</span><span class="name">Three Dimensional Angle</li>
+        <li><span class="unicode">&#x27C1</span><span class="text">⟁</span><span class="name">White Triangle Containing Small White Triangle</li>
+        <li><span class="unicode">&#x27C2</span><span class="text">⟂</span><span class="name">Perpendicular</li>
+        <li><span class="unicode">&#x27C3</span><span class="text">⟃</span><span class="name">Open Subset</li>
+        <li><span class="unicode">&#x27C4</span><span class="text">⟄</span><span class="name">Open Superset</li>
+        <li><span class="unicode">&#x27C7</span><span class="text">⟇</span><span class="name">or with Dot Inside</li>
+        <li><span class="unicode">&#x27C8</span><span class="text">⟈</span><span class="name">Reverse Solidus Preceding Subset</li>
+        <li><span class="unicode">&#x27C9</span><span class="text">⟉</span><span class="name">Superset Preceding Solidus</li>
+        <li><span class="unicode">&#x27CA</span><span class="text">⟊</span><span class="name">Vertical Bar with Horizontal Stroke</li>
+        <li><span class="unicode">&#x27CB</span><span class="text">⟋</span><span class="name">Mathematical Rising Diagonal</li>
+        <li><span class="unicode">&#x27CC</span><span class="text">⟌</span><span class="name">Long Division</li>
+        <li><span class="unicode">&#x27CD</span><span class="text">⟍</span><span class="name">Mathematical Falling Diagonal</li>
+        <li><span class="unicode">&#x27CE</span><span class="text">⟎</span><span class="name">Squared Logical And</li>
+        <li><span class="unicode">&#x27CF</span><span class="text">⟏</span><span class="name">Squared Logical Or</li>
+        <li><span class="unicode">&#x27D0</span><span class="text">⟐</span><span class="name">White Diamond with Centred Dot</li>
+        <li><span class="unicode">&#x27D1</span><span class="text">⟑</span><span class="name">and with Dot</li>
+        <li><span class="unicode">&#x27D2</span><span class="text">⟒</span><span class="name">Element of Opening Upwards</li>
+        <li><span class="unicode">&#x27D3</span><span class="text">⟓</span><span class="name">Lower Right Corner with Dot</li>
+        <li><span class="unicode">&#x27D4</span><span class="text">⟔</span><span class="name">Upper Left Corner with Dot</li>
+        <li><span class="unicode">&#x27D5</span><span class="text">⟕</span><span class="name">Left Outer Join</li>
+        <li><span class="unicode">&#x27D6</span><span class="text">⟖</span><span class="name">Right Outer Join</li>
+        <li><span class="unicode">&#x27D7</span><span class="text">⟗</span><span class="name">Full Outer Join</li>
+        <li><span class="unicode">&#x27D8</span><span class="text">⟘</span><span class="name">Large Up Tack</li>
+        <li><span class="unicode">&#x27D9</span><span class="text">⟙</span><span class="name">Large Down Tack</li>
+        <li><span class="unicode">&#x27DA</span><span class="text">⟚</span><span class="name">Left and Right Double Turnstile</li>
+        <li><span class="unicode">&#x27DB</span><span class="text">⟛</span><span class="name">Left and Right Tack</li>
+        <li><span class="unicode">&#x27DC</span><span class="text">⟜</span><span class="name">Left Multimap</li>
+        <li><span class="unicode">&#x27DD</span><span class="text">⟝</span><span class="name">Long Right Tack</li>
+        <li><span class="unicode">&#x27DE</span><span class="text">⟞</span><span class="name">Long Left Tack</li>
+        <li><span class="unicode">&#x27DF</span><span class="text">⟟</span><span class="name">Up Tack with Circle Above</li>
+        <li><span class="unicode">&#x27E0</span><span class="text">⟠</span><span class="name">Lozenge Divided By Horizontal Rule</li>
+        <li><span class="unicode">&#x27E1</span><span class="text">⟡</span><span class="name">White Concave-Sided Diamond</li>
+        <li><span class="unicode">&#x27E2</span><span class="text">⟢</span><span class="name">White Concave-Sided Diamond with Leftwards Tick</li>
+        <li><span class="unicode">&#x27E3</span><span class="text">⟣</span><span class="name">White Concave-Sided Diamond with Rightwards Tick</li>
+        <li><span class="unicode">&#x27E4</span><span class="text">⟤</span><span class="name">White Square with Leftwards Tick</li>
+        <li><span class="unicode">&#x27E5</span><span class="text">⟥</span><span class="name">White Square with Rightwards Tick</li>
+        <li><span class="unicode">&#x27F0</span><span class="text">⟰</span><span class="name">Upwards Quadruple Arrow</li>
+        <li><span class="unicode">&#x27F1</span><span class="text">⟱</span><span class="name">Downwards Quadruple Arrow</li>
+        <li><span class="unicode">&#x27F2</span><span class="text">⟲</span><span class="name">Anticlockwise Gapped Circle Arrow</li>
+        <li><span class="unicode">&#x27F3</span><span class="text">⟳</span><span class="name">Clockwise Gapped Circle Arrow</li>
+        <li><span class="unicode">&#x27F4</span><span class="text">⟴</span><span class="name">Right Arrow with Circled Plus</li>
+        <li><span class="unicode">&#x27F5</span><span class="text">⟵</span><span class="name">Long Leftwards Arrow</li>
+        <li><span class="unicode">&#x27F6</span><span class="text">⟶</span><span class="name">Long Rightwards Arrow</li>
+        <li><span class="unicode">&#x27F7</span><span class="text">⟷</span><span class="name">Long Left Right Arrow</li>
+        <li><span class="unicode">&#x27F8</span><span class="text">⟸</span><span class="name">Long Leftwards Double Arrow</li>
+        <li><span class="unicode">&#x27F9</span><span class="text">⟹</span><span class="name">Long Rightwards Double Arrow</li>
+        <li><span class="unicode">&#x27FA</span><span class="text">⟺</span><span class="name">Long Left Right Double Arrow</li>
+        <li><span class="unicode">&#x27FB</span><span class="text">⟻</span><span class="name">Long Leftwards Arrow from Bar</li>
+        <li><span class="unicode">&#x27FC</span><span class="text">⟼</span><span class="name">Long Rightwards Arrow from Bar</li>
+        <li><span class="unicode">&#x27FD</span><span class="text">⟽</span><span class="name">Long Leftwards Double Arrow from Bar</li>
+        <li><span class="unicode">&#x27FE</span><span class="text">⟾</span><span class="name">Long Rightwards Double Arrow from Bar</li>
+        <li><span class="unicode">&#x27FF</span><span class="text">⟿</span><span class="name">Long Rightwards Squiggle Arrow</li>
+        <li><span class="unicode">&#x2900</span><span class="text">⤀</span><span class="name">Rightwards Two-Headed Arrow with Vertical Stroke</li>
+        <li><span class="unicode">&#x2901</span><span class="text">⤁</span><span class="name">Rightwards Two-Headed Arrow with Double Vertical Stroke</li>
+        <li><span class="unicode">&#x2902</span><span class="text">⤂</span><span class="name">Leftwards Double Arrow with Vertical Stroke</li>
+        <li><span class="unicode">&#x2903</span><span class="text">⤃</span><span class="name">Rightwards Double Arrow with Vertical Stroke</li>
+        <li><span class="unicode">&#x2904</span><span class="text">⤄</span><span class="name">Left Right Double Arrow with Vertical Stroke</li>
+        <li><span class="unicode">&#x2905</span><span class="text">⤅</span><span class="name">Rightwards Two-Headed Arrow from Bar</li>
+        <li><span class="unicode">&#x2906</span><span class="text">⤆</span><span class="name">Leftwards Double Arrow from Bar</li>
+        <li><span class="unicode">&#x2907</span><span class="text">⤇</span><span class="name">Rightwards Double Arrow from Bar</li>
+        <li><span class="unicode">&#x2908</span><span class="text">⤈</span><span class="name">Downwards Arrow with Horizontal Stroke</li>
+        <li><span class="unicode">&#x2909</span><span class="text">⤉</span><span class="name">Upwards Arrow with Horizontal Stroke</li>
+        <li><span class="unicode">&#x290A</span><span class="text">⤊</span><span class="name">Upwards Triple Arrow</li>
+        <li><span class="unicode">&#x290B</span><span class="text">⤋</span><span class="name">Downwards Triple Arrow</li>
+        <li><span class="unicode">&#x290C</span><span class="text">⤌</span><span class="name">Leftwards Double Dash Arrow</li>
+        <li><span class="unicode">&#x290D</span><span class="text">⤍</span><span class="name">Rightwards Double Dash Arrow</li>
+        <li><span class="unicode">&#x290E</span><span class="text">⤎</span><span class="name">Leftwards Triple Dash Arrow</li>
+        <li><span class="unicode">&#x290F</span><span class="text">⤏</span><span class="name">Rightwards Triple Dash Arrow</li>
+        <li><span class="unicode">&#x2910</span><span class="text">⤐</span><span class="name">Rightwards Two-Headed Triple Dash Arrow</li>
+        <li><span class="unicode">&#x2911</span><span class="text">⤑</span><span class="name">Rightwards Arrow with Dotted Stem</li>
+        <li><span class="unicode">&#x2912</span><span class="text">⤒</span><span class="name">Upwards Arrow to Bar</li>
+        <li><span class="unicode">&#x2913</span><span class="text">⤓</span><span class="name">Downwards Arrow to Bar</li>
+        <li><span class="unicode">&#x2914</span><span class="text">⤔</span><span class="name">Rightwards Arrow with Tail with Vertical Stroke</li>
+        <li><span class="unicode">&#x2915</span><span class="text">⤕</span><span class="name">Rightwards Arrow with Tail with Double Vertical Stroke</li>
+        <li><span class="unicode">&#x2916</span><span class="text">⤖</span><span class="name">Rightwards Two-Headed Arrow with Tail</li>
+        <li><span class="unicode">&#x2917</span><span class="text">⤗</span><span class="name">Rightwards Two-Headed Arrow with Tail with Vertical Stroke</li>
+        <li><span class="unicode">&#x2918</span><span class="text">⤘</span><span class="name">Rightwards Two-Headed Arrow with Tail with Double Vertical Stroke</li>
+        <li><span class="unicode">&#x2919</span><span class="text">⤙</span><span class="name">Leftwards Arrow-Tail</li>
+        <li><span class="unicode">&#x291A</span><span class="text">⤚</span><span class="name">Rightwards Arrow-Tail</li>
+        <li><span class="unicode">&#x291B</span><span class="text">⤛</span><span class="name">Leftwards Double Arrow-Tail</li>
+        <li><span class="unicode">&#x291C</span><span class="text">⤜</span><span class="name">Rightwards Double Arrow-Tail</li>
+        <li><span class="unicode">&#x291D</span><span class="text">⤝</span><span class="name">Leftwards Arrow to Black Diamond</li>
+        <li><span class="unicode">&#x291E</span><span class="text">⤞</span><span class="name">Rightwards Arrow to Black Diamond</li>
+        <li><span class="unicode">&#x291F</span><span class="text">⤟</span><span class="name">Leftwards Arrow from Bar to Black Diamond</li>
+        <li><span class="unicode">&#x2920</span><span class="text">⤠</span><span class="name">Rightwards Arrow from Bar to Black Diamond</li>
+        <li><span class="unicode">&#x2921</span><span class="text">⤡</span><span class="name">North West and South East Arrow</li>
+        <li><span class="unicode">&#x2922</span><span class="text">⤢</span><span class="name">North East and South West Arrow</li>
+        <li><span class="unicode">&#x2923</span><span class="text">⤣</span><span class="name">North West Arrow with Hook</li>
+        <li><span class="unicode">&#x2924</span><span class="text">⤤</span><span class="name">North East Arrow with Hook</li>
+        <li><span class="unicode">&#x2925</span><span class="text">⤥</span><span class="name">South East Arrow with Hook</li>
+        <li><span class="unicode">&#x2926</span><span class="text">⤦</span><span class="name">South West Arrow with Hook</li>
+        <li><span class="unicode">&#x2927</span><span class="text">⤧</span><span class="name">North West Arrow and North East Arrow</li>
+        <li><span class="unicode">&#x2928</span><span class="text">⤨</span><span class="name">North East Arrow and South East Arrow</li>
+        <li><span class="unicode">&#x2929</span><span class="text">⤩</span><span class="name">South East Arrow and South West Arrow</li>
+        <li><span class="unicode">&#x292A</span><span class="text">⤪</span><span class="name">South West Arrow and North West Arrow</li>
+        <li><span class="unicode">&#x292B</span><span class="text">⤫</span><span class="name">Rising Diagonal Crossing Falling Diagonal</li>
+        <li><span class="unicode">&#x292C</span><span class="text">⤬</span><span class="name">Falling Diagonal Crossing Rising Diagonal</li>
+        <li><span class="unicode">&#x292D</span><span class="text">⤭</span><span class="name">South East Arrow Crossing North East Arrow</li>
+        <li><span class="unicode">&#x292E</span><span class="text">⤮</span><span class="name">North East Arrow Crossing South East Arrow</li>
+        <li><span class="unicode">&#x292F</span><span class="text">⤯</span><span class="name">Falling Diagonal Crossing North East Arrow</li>
+        <li><span class="unicode">&#x2930</span><span class="text">⤰</span><span class="name">Rising Diagonal Crossing South East Arrow</li>
+        <li><span class="unicode">&#x2931</span><span class="text">⤱</span><span class="name">North East Arrow Crossing North West Arrow</li>
+        <li><span class="unicode">&#x2932</span><span class="text">⤲</span><span class="name">North West Arrow Crossing North East Arrow</li>
+        <li><span class="unicode">&#x2933</span><span class="text">⤳</span><span class="name">Wave Arrow Pointing Directly Right</li>
+        <li><span class="unicode">&#x2934</span><span class="text">⤴</span><span class="name">Arrow Pointing Rightwards Then Curving Upwards</li>
+        <li><span class="unicode">&#x2935</span><span class="text">⤵</span><span class="name">Arrow Pointing Rightwards Then Curving Downwards</li>
+        <li><span class="unicode">&#x2936</span><span class="text">⤶</span><span class="name">Arrow Pointing Downwards Then Curving Leftwards</li>
+        <li><span class="unicode">&#x2937</span><span class="text">⤷</span><span class="name">Arrow Pointing Downwards Then Curving Rightwards</li>
+        <li><span class="unicode">&#x2938</span><span class="text">⤸</span><span class="name">Right-Side Arc Clockwise Arrow</li>
+        <li><span class="unicode">&#x2939</span><span class="text">⤹</span><span class="name">Left-Side Arc Anticlockwise Arrow</li>
+        <li><span class="unicode">&#x293A</span><span class="text">⤺</span><span class="name">Top Arc Anticlockwise Arrow</li>
+        <li><span class="unicode">&#x293B</span><span class="text">⤻</span><span class="name">Bottom Arc Anticlockwise Arrow</li>
+        <li><span class="unicode">&#x293C</span><span class="text">⤼</span><span class="name">Top Arc Clockwise Arrow with Minus</li>
+        <li><span class="unicode">&#x293D</span><span class="text">⤽</span><span class="name">Top Arc Anticlockwise Arrow with Plus</li>
+        <li><span class="unicode">&#x293E</span><span class="text">⤾</span><span class="name">Lower Right Semicircular Clockwise Arrow</li>
+        <li><span class="unicode">&#x293F</span><span class="text">⤿</span><span class="name">Lower Left Semicircular Anticlockwise Arrow</li>
+        <li><span class="unicode">&#x2940</span><span class="text">⥀</span><span class="name">Anticlockwise Closed Circle Arrow</li>
+        <li><span class="unicode">&#x2941</span><span class="text">⥁</span><span class="name">Clockwise Closed Circle Arrow</li>
+        <li><span class="unicode">&#x2942</span><span class="text">⥂</span><span class="name">Rightwards Arrow Above Short Leftwards Arrow</li>
+        <li><span class="unicode">&#x2943</span><span class="text">⥃</span><span class="name">Leftwards Arrow Above Short Rightwards Arrow</li>
+        <li><span class="unicode">&#x2944</span><span class="text">⥄</span><span class="name">Short Rightwards Arrow Above Leftwards Arrow</li>
+        <li><span class="unicode">&#x2945</span><span class="text">⥅</span><span class="name">Rightwards Arrow with Plus Below</li>
+        <li><span class="unicode">&#x2946</span><span class="text">⥆</span><span class="name">Leftwards Arrow with Plus Below</li>
+        <li><span class="unicode">&#x2947</span><span class="text">⥇</span><span class="name">Rightwards Arrow Through X</li>
+        <li><span class="unicode">&#x2948</span><span class="text">⥈</span><span class="name">Left Right Arrow Through Small Circle</li>
+        <li><span class="unicode">&#x2949</span><span class="text">⥉</span><span class="name">Upwards Two-Headed Arrow from Small Circle</li>
+        <li><span class="unicode">&#x294A</span><span class="text">⥊</span><span class="name">Left Barb Up Right Barb Down Harpoon</li>
+        <li><span class="unicode">&#x294B</span><span class="text">⥋</span><span class="name">Left Barb Down Right Barb Up Harpoon</li>
+        <li><span class="unicode">&#x294C</span><span class="text">⥌</span><span class="name">Up Barb Right Down Barb Left Harpoon</li>
+        <li><span class="unicode">&#x294D</span><span class="text">⥍</span><span class="name">Up Barb Left Down Barb Right Harpoon</li>
+        <li><span class="unicode">&#x294E</span><span class="text">⥎</span><span class="name">Left Barb Up Right Barb Up Harpoon</li>
+        <li><span class="unicode">&#x294F</span><span class="text">⥏</span><span class="name">Up Barb Right Down Barb Right Harpoon</li>
+        <li><span class="unicode">&#x2950</span><span class="text">⥐</span><span class="name">Left Barb Down Right Barb Down Harpoon</li>
+        <li><span class="unicode">&#x2951</span><span class="text">⥑</span><span class="name">Up Barb Left Down Barb Left Harpoon</li>
+        <li><span class="unicode">&#x2952</span><span class="text">⥒</span><span class="name">Leftwards Harpoon with Barb Up to Bar</li>
+        <li><span class="unicode">&#x2953</span><span class="text">⥓</span><span class="name">Rightwards Harpoon with Barb Up to Bar</li>
+        <li><span class="unicode">&#x2954</span><span class="text">⥔</span><span class="name">Upwards Harpoon with Barb Right to Bar</li>
+        <li><span class="unicode">&#x2955</span><span class="text">⥕</span><span class="name">Downwards Harpoon with Barb Right to Bar</li>
+        <li><span class="unicode">&#x2956</span><span class="text">⥖</span><span class="name">Leftwards Harpoon with Barb Down to Bar</li>
+        <li><span class="unicode">&#x2957</span><span class="text">⥗</span><span class="name">Rightwards Harpoon with Barb Down to Bar</li>
+        <li><span class="unicode">&#x2958</span><span class="text">⥘</span><span class="name">Upwards Harpoon with Barb Left to Bar</li>
+        <li><span class="unicode">&#x2959</span><span class="text">⥙</span><span class="name">Downwards Harpoon with Barb Left to Bar</li>
+        <li><span class="unicode">&#x295A</span><span class="text">⥚</span><span class="name">Leftwards Harpoon with Barb Up from Bar</li>
+        <li><span class="unicode">&#x295B</span><span class="text">⥛</span><span class="name">Rightwards Harpoon with Barb Up from Bar</li>
+        <li><span class="unicode">&#x295C</span><span class="text">⥜</span><span class="name">Upwards Harpoon with Barb Right from Bar</li>
+        <li><span class="unicode">&#x295D</span><span class="text">⥝</span><span class="name">Downwards Harpoon with Barb Right from Bar</li>
+        <li><span class="unicode">&#x295E</span><span class="text">⥞</span><span class="name">Leftwards Harpoon with Barb Down from Bar</li>
+        <li><span class="unicode">&#x295F</span><span class="text">⥟</span><span class="name">Rightwards Harpoon with Barb Down from Bar</li>
+        <li><span class="unicode">&#x2960</span><span class="text">⥠</span><span class="name">Upwards Harpoon with Barb Left from Bar</li>
+        <li><span class="unicode">&#x2961</span><span class="text">⥡</span><span class="name">Downwards Harpoon with Barb Left from Bar</li>
+        <li><span class="unicode">&#x2962</span><span class="text">⥢</span><span class="name">Leftwards Harpoon with Barb Up Above Leftwards Harpoon with Barb Down</li>
+        <li><span class="unicode">&#x2963</span><span class="text">⥣</span><span class="name">Upwards Harpoon with Barb Left Beside Upwards Harpoon with Barb Right</li>
+        <li><span class="unicode">&#x2964</span><span class="text">⥤</span><span class="name">Rightwards Harpoon with Barb Up Above Rightwards Harpoon with Barb Down</li>
+        <li><span class="unicode">&#x2965</span><span class="text">⥥</span><span class="name">Downwards Harpoon with Barb Left Beside Downwards Harpoon with Barb Right</li>
+        <li><span class="unicode">&#x2966</span><span class="text">⥦</span><span class="name">Leftwards Harpoon with Barb Up Above Rightwards Harpoon with Barb Up</li>
+        <li><span class="unicode">&#x2967</span><span class="text">⥧</span><span class="name">Leftwards Harpoon with Barb Down Above Rightwards Harpoon with Barb Down</li>
+        <li><span class="unicode">&#x2968</span><span class="text">⥨</span><span class="name">Rightwards Harpoon with Barb Up Above Leftwards Harpoon with Barb Up</li>
+        <li><span class="unicode">&#x2969</span><span class="text">⥩</span><span class="name">Rightwards Harpoon with Barb Down Above Leftwards Harpoon with Barb Down</li>
+        <li><span class="unicode">&#x296A</span><span class="text">⥪</span><span class="name">Leftwards Harpoon with Barb Up Above Long Dash</li>
+        <li><span class="unicode">&#x296B</span><span class="text">⥫</span><span class="name">Leftwards Harpoon with Barb Down Below Long Dash</li>
+        <li><span class="unicode">&#x296C</span><span class="text">⥬</span><span class="name">Rightwards Harpoon with Barb Up Above Long Dash</li>
+        <li><span class="unicode">&#x296D</span><span class="text">⥭</span><span class="name">Rightwards Harpoon with Barb Down Below Long Dash</li>
+        <li><span class="unicode">&#x296E</span><span class="text">⥮</span><span class="name">Upwards Harpoon with Barb Left Beside Downwards Harpoon with Barb Right</li>
+        <li><span class="unicode">&#x296F</span><span class="text">⥯</span><span class="name">Downwards Harpoon with Barb Left Beside Upwards Harpoon with Barb Right</li>
+        <li><span class="unicode">&#x2970</span><span class="text">⥰</span><span class="name">Right Double Arrow with Rounded Head</li>
+        <li><span class="unicode">&#x2971</span><span class="text">⥱</span><span class="name">Equals Sign Above Rightwards Arrow</li>
+        <li><span class="unicode">&#x2972</span><span class="text">⥲</span><span class="name">Tilde Operator Above Rightwards Arrow</li>
+        <li><span class="unicode">&#x2973</span><span class="text">⥳</span><span class="name">Leftwards Arrow Above Tilde Operator</li>
+        <li><span class="unicode">&#x2974</span><span class="text">⥴</span><span class="name">Rightwards Arrow Above Tilde Operator</li>
+        <li><span class="unicode">&#x2975</span><span class="text">⥵</span><span class="name">Rightwards Arrow Above Almost Equal To</li>
+        <li><span class="unicode">&#x2976</span><span class="text">⥶</span><span class="name">Less-Than Above Leftwards Arrow</li>
+        <li><span class="unicode">&#x2977</span><span class="text">⥷</span><span class="name">Leftwards Arrow Through Less-Than</li>
+        <li><span class="unicode">&#x2978</span><span class="text">⥸</span><span class="name">Greater-Than Above Rightwards Arrow</li>
+        <li><span class="unicode">&#x2979</span><span class="text">⥹</span><span class="name">Subset Above Rightwards Arrow</li>
+        <li><span class="unicode">&#x297A</span><span class="text">⥺</span><span class="name">Leftwards Arrow Through Subset</li>
+        <li><span class="unicode">&#x297B</span><span class="text">⥻</span><span class="name">Superset Above Leftwards Arrow</li>
+        <li><span class="unicode">&#x297C</span><span class="text">⥼</span><span class="name">Left Fish Tail</li>
+        <li><span class="unicode">&#x297D</span><span class="text">⥽</span><span class="name">Right Fish Tail</li>
+        <li><span class="unicode">&#x297E</span><span class="text">⥾</span><span class="name">Up Fish Tail</li>
+        <li><span class="unicode">&#x297F</span><span class="text">⥿</span><span class="name">Down Fish Tail</li>
+        <li><span class="unicode">&#x2980</span><span class="text">⦀</span><span class="name">Triple Vertical Bar Delimiter</li>
+        <li><span class="unicode">&#x2981</span><span class="text">⦁</span><span class="name">Z Notation Spot</li>
+        <li><span class="unicode">&#x2982</span><span class="text">⦂</span><span class="name">Z Notation Type Colon</li>
+        <li><span class="unicode">&#x2999</span><span class="text">⦙</span><span class="name">Dotted Fence</li>
+        <li><span class="unicode">&#x299A</span><span class="text">⦚</span><span class="name">Vertical Zigzag Line</li>
+        <li><span class="unicode">&#x299B</span><span class="text">⦛</span><span class="name">Measured Angle Opening Left</li>
+        <li><span class="unicode">&#x299C</span><span class="text">⦜</span><span class="name">Right Angle Variant with Square</li>
+        <li><span class="unicode">&#x299D</span><span class="text">⦝</span><span class="name">Measured Right Angle with Dot</li>
+        <li><span class="unicode">&#x299E</span><span class="text">⦞</span><span class="name">Angle with S Inside</li>
+        <li><span class="unicode">&#x299F</span><span class="text">⦟</span><span class="name">Acute Angle</li>
+        <li><span class="unicode">&#x29A0</span><span class="text">⦠</span><span class="name">Spherical Angle Opening Left</li>
+        <li><span class="unicode">&#x29A1</span><span class="text">⦡</span><span class="name">Spherical Angle Opening Up</li>
+        <li><span class="unicode">&#x29A2</span><span class="text">⦢</span><span class="name">Turned Angle</li>
+        <li><span class="unicode">&#x29A3</span><span class="text">⦣</span><span class="name">Reversed Angle</li>
+        <li><span class="unicode">&#x29A4</span><span class="text">⦤</span><span class="name">Angle with Underbar</li>
+        <li><span class="unicode">&#x29A5</span><span class="text">⦥</span><span class="name">Reversed Angle with Underbar</li>
+        <li><span class="unicode">&#x29A6</span><span class="text">⦦</span><span class="name">Oblique Angle Opening Up</li>
+        <li><span class="unicode">&#x29A7</span><span class="text">⦧</span><span class="name">Oblique Angle Opening Down</li>
+        <li><span class="unicode">&#x29A8</span><span class="text">⦨</span><span class="name">Measured Angle with Open Arm Ending In Arrow Pointing Up and Right</li>
+        <li><span class="unicode">&#x29A9</span><span class="text">⦩</span><span class="name">Measured Angle with Open Arm Ending In Arrow Pointing Up and Left</li>
+        <li><span class="unicode">&#x29AA</span><span class="text">⦪</span><span class="name">Measured Angle with Open Arm Ending In Arrow Pointing Down and Right</li>
+        <li><span class="unicode">&#x29AB</span><span class="text">⦫</span><span class="name">Measured Angle with Open Arm Ending In Arrow Pointing Down and Left</li>
+        <li><span class="unicode">&#x29AC</span><span class="text">⦬</span><span class="name">Measured Angle with Open Arm Ending In Arrow Pointing Right and Up</li>
+        <li><span class="unicode">&#x29AD</span><span class="text">⦭</span><span class="name">Measured Angle with Open Arm Ending In Arrow Pointing Left and Up</li>
+        <li><span class="unicode">&#x29AE</span><span class="text">⦮</span><span class="name">Measured Angle with Open Arm Ending In Arrow Pointing Right and Down</li>
+        <li><span class="unicode">&#x29AF</span><span class="text">⦯</span><span class="name">Measured Angle with Open Arm Ending In Arrow Pointing Left and Down</li>
+        <li><span class="unicode">&#x29B0</span><span class="text">⦰</span><span class="name">Reversed Empty Set</li>
+        <li><span class="unicode">&#x29B1</span><span class="text">⦱</span><span class="name">Empty Set with Overbar</li>
+        <li><span class="unicode">&#x29B2</span><span class="text">⦲</span><span class="name">Empty Set with Small Circle Above</li>
+        <li><span class="unicode">&#x29B3</span><span class="text">⦳</span><span class="name">Empty Set with Right Arrow Above</li>
+        <li><span class="unicode">&#x29B4</span><span class="text">⦴</span><span class="name">Empty Set with Left Arrow Above</li>
+        <li><span class="unicode">&#x29B5</span><span class="text">⦵</span><span class="name">Circle with Horizontal Bar</li>
+        <li><span class="unicode">&#x29B6</span><span class="text">⦶</span><span class="name">Circled Vertical Bar</li>
+        <li><span class="unicode">&#x29B7</span><span class="text">⦷</span><span class="name">Circled Parallel</li>
+        <li><span class="unicode">&#x29B8</span><span class="text">⦸</span><span class="name">Circled Reverse Solidus</li>
+        <li><span class="unicode">&#x29B9</span><span class="text">⦹</span><span class="name">Circled Perpendicular</li>
+        <li><span class="unicode">&#x29BA</span><span class="text">⦺</span><span class="name">Circle Divided By Horizontal Bar and Top Half Divided By Vertical Bar</li>
+        <li><span class="unicode">&#x29BB</span><span class="text">⦻</span><span class="name">Circle with Superimposed X</li>
+        <li><span class="unicode">&#x29BC</span><span class="text">⦼</span><span class="name">Circled Anticlockwise-Rotated Division Sign</li>
+        <li><span class="unicode">&#x29BD</span><span class="text">⦽</span><span class="name">Up Arrow Through Circle</li>
+        <li><span class="unicode">&#x29BE</span><span class="text">⦾</span><span class="name">Circled White Bullet</li>
+        <li><span class="unicode">&#x29BF</span><span class="text">⦿</span><span class="name">Circled Bullet</li>
+        <li><span class="unicode">&#x29C0</span><span class="text">⧀</span><span class="name">Circled Less-Than</li>
+        <li><span class="unicode">&#x29C1</span><span class="text">⧁</span><span class="name">Circled Greater-Than</li>
+        <li><span class="unicode">&#x29C2</span><span class="text">⧂</span><span class="name">Circle with Small Circle to the Right</li>
+        <li><span class="unicode">&#x29C3</span><span class="text">⧃</span><span class="name">Circle with Two Horizontal Strokes to the Right</li>
+        <li><span class="unicode">&#x29C4</span><span class="text">⧄</span><span class="name">Squared Rising Diagonal Slash</li>
+        <li><span class="unicode">&#x29C5</span><span class="text">⧅</span><span class="name">Squared Falling Diagonal Slash</li>
+        <li><span class="unicode">&#x29C6</span><span class="text">⧆</span><span class="name">Squared Asterisk</li>
+        <li><span class="unicode">&#x29C7</span><span class="text">⧇</span><span class="name">Squared Small Circle</li>
+        <li><span class="unicode">&#x29C8</span><span class="text">⧈</span><span class="name">Squared Square</li>
+        <li><span class="unicode">&#x29C9</span><span class="text">⧉</span><span class="name">Two Joined Squares</li>
+        <li><span class="unicode">&#x29CA</span><span class="text">⧊</span><span class="name">Triangle with Dot Above</li>
+        <li><span class="unicode">&#x29CB</span><span class="text">⧋</span><span class="name">Triangle with Underbar</li>
+        <li><span class="unicode">&#x29CC</span><span class="text">⧌</span><span class="name">S In Triangle</li>
+        <li><span class="unicode">&#x29CD</span><span class="text">⧍</span><span class="name">Triangle with Serifs at Bottom</li>
+        <li><span class="unicode">&#x29CE</span><span class="text">⧎</span><span class="name">Right Triangle Above Left Triangle</li>
+        <li><span class="unicode">&#x29CF</span><span class="text">⧏</span><span class="name">Left Triangle Beside Vertical Bar</li>
+        <li><span class="unicode">&#x29D0</span><span class="text">⧐</span><span class="name">Vertical Bar Beside Right Triangle</li>
+        <li><span class="unicode">&#x29D1</span><span class="text">⧑</span><span class="name">Bowtie with Left Half Black</li>
+        <li><span class="unicode">&#x29D2</span><span class="text">⧒</span><span class="name">Bowtie with Right Half Black</li>
+        <li><span class="unicode">&#x29D3</span><span class="text">⧓</span><span class="name">Black Bowtie</li>
+        <li><span class="unicode">&#x29D4</span><span class="text">⧔</span><span class="name">Times with Left Half Black</li>
+        <li><span class="unicode">&#x29D5</span><span class="text">⧕</span><span class="name">Times with Right Half Black</li>
+        <li><span class="unicode">&#x29D6</span><span class="text">⧖</span><span class="name">White Hourglass</li>
+        <li><span class="unicode">&#x29D7</span><span class="text">⧗</span><span class="name">Black Hourglass</li>
+        <li><span class="unicode">&#x29DC</span><span class="text">⧜</span><span class="name">Incomplete Infinity</li>
+        <li><span class="unicode">&#x29DD</span><span class="text">⧝</span><span class="name">Tie Over Infinity</li>
+        <li><span class="unicode">&#x29DE</span><span class="text">⧞</span><span class="name">Infinity Negated with Vertical Bar</li>
+        <li><span class="unicode">&#x29DF</span><span class="text">⧟</span><span class="name">Double-Ended Multimap</li>
+        <li><span class="unicode">&#x29E0</span><span class="text">⧠</span><span class="name">Square with Contoured Outline</li>
+        <li><span class="unicode">&#x29E1</span><span class="text">⧡</span><span class="name">Increases As</li>
+        <li><span class="unicode">&#x29E2</span><span class="text">⧢</span><span class="name">Shuffle Product</li>
+        <li><span class="unicode">&#x29E3</span><span class="text">⧣</span><span class="name">Equals Sign and Slanted Parallel</li>
+        <li><span class="unicode">&#x29E4</span><span class="text">⧤</span><span class="name">Equals Sign and Slanted Parallel with Tilde Above</li>
+        <li><span class="unicode">&#x29E5</span><span class="text">⧥</span><span class="name">Identical to and Slanted Parallel</li>
+        <li><span class="unicode">&#x29E6</span><span class="text">⧦</span><span class="name">Gleich Stark</li>
+        <li><span class="unicode">&#x29E7</span><span class="text">⧧</span><span class="name">Thermodynamic</li>
+        <li><span class="unicode">&#x29E8</span><span class="text">⧨</span><span class="name">Down-Pointing Triangle with Left Half Black</li>
+        <li><span class="unicode">&#x29E9</span><span class="text">⧩</span><span class="name">Down-Pointing Triangle with Right Half Black</li>
+        <li><span class="unicode">&#x29EA</span><span class="text">⧪</span><span class="name">Black Diamond with Down Arrow</li>
+        <li><span class="unicode">&#x29EB</span><span class="text">⧫</span><span class="name">Black Lozenge</li>
+        <li><span class="unicode">&#x29EC</span><span class="text">⧬</span><span class="name">White Circle with Down Arrow</li>
+        <li><span class="unicode">&#x29ED</span><span class="text">⧭</span><span class="name">Black Circle with Down Arrow</li>
+        <li><span class="unicode">&#x29EE</span><span class="text">⧮</span><span class="name">Error-Barred White Square</li>
+        <li><span class="unicode">&#x29EF</span><span class="text">⧯</span><span class="name">Error-Barred Black Square</li>
+        <li><span class="unicode">&#x29F0</span><span class="text">⧰</span><span class="name">Error-Barred White Diamond</li>
+        <li><span class="unicode">&#x29F1</span><span class="text">⧱</span><span class="name">Error-Barred Black Diamond</li>
+        <li><span class="unicode">&#x29F2</span><span class="text">⧲</span><span class="name">Error-Barred White Circle</li>
+        <li><span class="unicode">&#x29F3</span><span class="text">⧳</span><span class="name">Error-Barred Black Circle</li>
+        <li><span class="unicode">&#x29F4</span><span class="text">⧴</span><span class="name">Rule-Delayed</li>
+        <li><span class="unicode">&#x29F5</span><span class="text">⧵</span><span class="name">Reverse Solidus Operator</li>
+        <li><span class="unicode">&#x29F6</span><span class="text">⧶</span><span class="name">Solidus with Overbar</li>
+        <li><span class="unicode">&#x29F7</span><span class="text">⧷</span><span class="name">Reverse Solidus with Horizontal Stroke</li>
+        <li><span class="unicode">&#x29F8</span><span class="text">⧸</span><span class="name">Big Solidus</li>
+        <li><span class="unicode">&#x29F9</span><span class="text">⧹</span><span class="name">Big Reverse Solidus</li>
+        <li><span class="unicode">&#x29FA</span><span class="text">⧺</span><span class="name">Double Plus</li>
+        <li><span class="unicode">&#x29FB</span><span class="text">⧻</span><span class="name">Triple Plus</li>
+        <li><span class="unicode">&#x29FE</span><span class="text">⧾</span><span class="name">Tiny</li>
+        <li><span class="unicode">&#x29FF</span><span class="text">⧿</span><span class="name">Miny</li>
+        <li><span class="unicode">&#x2A00</span><span class="text">⨀</span><span class="name">N-Ary Circled Dot Operator</li>
+        <li><span class="unicode">&#x2A01</span><span class="text">⨁</span><span class="name">N-Ary Circled Plus Operator</li>
+        <li><span class="unicode">&#x2A02</span><span class="text">⨂</span><span class="name">N-Ary Circled Times Operator</li>
+        <li><span class="unicode">&#x2A03</span><span class="text">⨃</span><span class="name">N-Ary Union Operator with Dot</li>
+        <li><span class="unicode">&#x2A04</span><span class="text">⨄</span><span class="name">N-Ary Union Operator with Plus</li>
+        <li><span class="unicode">&#x2A05</span><span class="text">⨅</span><span class="name">N-Ary Square Intersection Operator</li>
+        <li><span class="unicode">&#x2A06</span><span class="text">⨆</span><span class="name">N-Ary Square Union Operator</li>
+        <li><span class="unicode">&#x2A07</span><span class="text">⨇</span><span class="name">Two Logical and Operator</li>
+        <li><span class="unicode">&#x2A08</span><span class="text">⨈</span><span class="name">Two Logical or Operator</li>
+        <li><span class="unicode">&#x2A09</span><span class="text">⨉</span><span class="name">N-Ary Times Operator</li>
+        <li><span class="unicode">&#x2A0A</span><span class="text">⨊</span><span class="name">Modulo Two Sum</li>
+        <li><span class="unicode">&#x2A0B</span><span class="text">⨋</span><span class="name">Summation with Integral</li>
+        <li><span class="unicode">&#x2A0C</span><span class="text">⨌</span><span class="name">Quadruple Integral Operator</li>
+        <li><span class="unicode">&#x2A0D</span><span class="text">⨍</span><span class="name">Finite Part Integral</li>
+        <li><span class="unicode">&#x2A0E</span><span class="text">⨎</span><span class="name">Integral with Double Stroke</li>
+        <li><span class="unicode">&#x2A0F</span><span class="text">⨏</span><span class="name">Integral Average with Slash</li>
+        <li><span class="unicode">&#x2A10</span><span class="text">⨐</span><span class="name">Circulation Function</li>
+        <li><span class="unicode">&#x2A11</span><span class="text">⨑</span><span class="name">Anticlockwise Integration</li>
+        <li><span class="unicode">&#x2A12</span><span class="text">⨒</span><span class="name">Line Integration with Rectangular Path Around Pole</li>
+        <li><span class="unicode">&#x2A13</span><span class="text">⨓</span><span class="name">Line Integration with Semicircular Path Around Pole</li>
+        <li><span class="unicode">&#x2A14</span><span class="text">⨔</span><span class="name">Line Integration Not Including the Pole</li>
+        <li><span class="unicode">&#x2A15</span><span class="text">⨕</span><span class="name">Integral Around A Point Operator</li>
+        <li><span class="unicode">&#x2A16</span><span class="text">⨖</span><span class="name">Quaternion Integral Operator</li>
+        <li><span class="unicode">&#x2A17</span><span class="text">⨗</span><span class="name">Integral with Leftwards Arrow with Hook</li>
+        <li><span class="unicode">&#x2A18</span><span class="text">⨘</span><span class="name">Integral with Times Sign</li>
+        <li><span class="unicode">&#x2A19</span><span class="text">⨙</span><span class="name">Integral with Intersection</li>
+        <li><span class="unicode">&#x2A1A</span><span class="text">⨚</span><span class="name">Integral with Union</li>
+        <li><span class="unicode">&#x2A1B</span><span class="text">⨛</span><span class="name">Integral with Overbar</li>
+        <li><span class="unicode">&#x2A1C</span><span class="text">⨜</span><span class="name">Integral with Underbar</li>
+        <li><span class="unicode">&#x2A1D</span><span class="text">⨝</span><span class="name">Join</li>
+        <li><span class="unicode">&#x2A1E</span><span class="text">⨞</span><span class="name">Large Left Triangle Operator</li>
+        <li><span class="unicode">&#x2A1F</span><span class="text">⨟</span><span class="name">Z Notation Schema Composition</li>
+        <li><span class="unicode">&#x2A20</span><span class="text">⨠</span><span class="name">Z Notation Schema Piping</li>
+        <li><span class="unicode">&#x2A21</span><span class="text">⨡</span><span class="name">Z Notation Schema Projection</li>
+        <li><span class="unicode">&#x2A22</span><span class="text">⨢</span><span class="name">Plus Sign with Small Circle Above</li>
+        <li><span class="unicode">&#x2A23</span><span class="text">⨣</span><span class="name">Plus Sign with Circumflex Accent Above</li>
+        <li><span class="unicode">&#x2A24</span><span class="text">⨤</span><span class="name">Plus Sign with Tilde Above</li>
+        <li><span class="unicode">&#x2A25</span><span class="text">⨥</span><span class="name">Plus Sign with Dot Below</li>
+        <li><span class="unicode">&#x2A26</span><span class="text">⨦</span><span class="name">Plus Sign with Tilde Below</li>
+        <li><span class="unicode">&#x2A27</span><span class="text">⨧</span><span class="name">Plus Sign with Subscript Two</li>
+        <li><span class="unicode">&#x2A28</span><span class="text">⨨</span><span class="name">Plus Sign with Black Triangle</li>
+        <li><span class="unicode">&#x2A29</span><span class="text">⨩</span><span class="name">Minus Sign with Comma Above</li>
+        <li><span class="unicode">&#x2A2A</span><span class="text">⨪</span><span class="name">Minus Sign with Dot Below</li>
+        <li><span class="unicode">&#x2A2B</span><span class="text">⨫</span><span class="name">Minus Sign with Falling Dots</li>
+        <li><span class="unicode">&#x2A2C</span><span class="text">⨬</span><span class="name">Minus Sign with Rising Dots</li>
+        <li><span class="unicode">&#x2A2D</span><span class="text">⨭</span><span class="name">Plus Sign In Left Half Circle</li>
+        <li><span class="unicode">&#x2A2E</span><span class="text">⨮</span><span class="name">Plus Sign In Right Half Circle</li>
+        <li><span class="unicode">&#x2A2F</span><span class="text">⨯</span><span class="name">Vector or Cross Product</li>
+        <li><span class="unicode">&#x2A30</span><span class="text">⨰</span><span class="name">Multiplication Sign with Dot Above</li>
+        <li><span class="unicode">&#x2A31</span><span class="text">⨱</span><span class="name">Multiplication Sign with Underbar</li>
+        <li><span class="unicode">&#x2A32</span><span class="text">⨲</span><span class="name">Semidirect Product with Bottom Closed</li>
+        <li><span class="unicode">&#x2A33</span><span class="text">⨳</span><span class="name">Smash Product</li>
+        <li><span class="unicode">&#x2A34</span><span class="text">⨴</span><span class="name">Multiplication Sign In Left Half Circle</li>
+        <li><span class="unicode">&#x2A35</span><span class="text">⨵</span><span class="name">Multiplication Sign In Right Half Circle</li>
+        <li><span class="unicode">&#x2A36</span><span class="text">⨶</span><span class="name">Circled Multiplication Sign with Circumflex Accent</li>
+        <li><span class="unicode">&#x2A37</span><span class="text">⨷</span><span class="name">Multiplication Sign In Double Circle</li>
+        <li><span class="unicode">&#x2A38</span><span class="text">⨸</span><span class="name">Circled Division Sign</li>
+        <li><span class="unicode">&#x2A39</span><span class="text">⨹</span><span class="name">Plus Sign In Triangle</li>
+        <li><span class="unicode">&#x2A3A</span><span class="text">⨺</span><span class="name">Minus Sign In Triangle</li>
+        <li><span class="unicode">&#x2A3B</span><span class="text">⨻</span><span class="name">Multiplication Sign In Triangle</li>
+        <li><span class="unicode">&#x2A3C</span><span class="text">⨼</span><span class="name">Interior Product</li>
+        <li><span class="unicode">&#x2A3D</span><span class="text">⨽</span><span class="name">Righthand Interior Product</li>
+        <li><span class="unicode">&#x2A3E</span><span class="text">⨾</span><span class="name">Z Notation Relational Composition</li>
+        <li><span class="unicode">&#x2A3F</span><span class="text">⨿</span><span class="name">Amalgamation or Coproduct</li>
+        <li><span class="unicode">&#x2A40</span><span class="text">⩀</span><span class="name">Intersection with Dot</li>
+        <li><span class="unicode">&#x2A41</span><span class="text">⩁</span><span class="name">Union with Minus Sign</li>
+        <li><span class="unicode">&#x2A42</span><span class="text">⩂</span><span class="name">Union with Overbar</li>
+        <li><span class="unicode">&#x2A43</span><span class="text">⩃</span><span class="name">Intersection with Overbar</li>
+        <li><span class="unicode">&#x2A44</span><span class="text">⩄</span><span class="name">Intersection with Logical And</li>
+        <li><span class="unicode">&#x2A45</span><span class="text">⩅</span><span class="name">Union with Logical Or</li>
+        <li><span class="unicode">&#x2A46</span><span class="text">⩆</span><span class="name">Union Above Intersection</li>
+        <li><span class="unicode">&#x2A47</span><span class="text">⩇</span><span class="name">Intersection Above Union</li>
+        <li><span class="unicode">&#x2A48</span><span class="text">⩈</span><span class="name">Union Above Bar Above Intersection</li>
+        <li><span class="unicode">&#x2A49</span><span class="text">⩉</span><span class="name">Intersection Above Bar Above Union</li>
+        <li><span class="unicode">&#x2A4A</span><span class="text">⩊</span><span class="name">Union Beside and Joined with Union</li>
+        <li><span class="unicode">&#x2A4B</span><span class="text">⩋</span><span class="name">Intersection Beside and Joined with Intersection</li>
+        <li><span class="unicode">&#x2A4C</span><span class="text">⩌</span><span class="name">Closed Union with Serifs</li>
+        <li><span class="unicode">&#x2A4D</span><span class="text">⩍</span><span class="name">Closed Intersection with Serifs</li>
+        <li><span class="unicode">&#x2A4E</span><span class="text">⩎</span><span class="name">Double Square Intersection</li>
+        <li><span class="unicode">&#x2A4F</span><span class="text">⩏</span><span class="name">Double Square Union</li>
+        <li><span class="unicode">&#x2A50</span><span class="text">⩐</span><span class="name">Closed Union with Serifs and Smash Product</li>
+        <li><span class="unicode">&#x2A51</span><span class="text">⩑</span><span class="name">Logical and with Dot Above</li>
+        <li><span class="unicode">&#x2A52</span><span class="text">⩒</span><span class="name">Logical or with Dot Above</li>
+        <li><span class="unicode">&#x2A53</span><span class="text">⩓</span><span class="name">Double Logical And</li>
+        <li><span class="unicode">&#x2A54</span><span class="text">⩔</span><span class="name">Double Logical Or</li>
+        <li><span class="unicode">&#x2A55</span><span class="text">⩕</span><span class="name">Two Intersecting Logical And</li>
+        <li><span class="unicode">&#x2A56</span><span class="text">⩖</span><span class="name">Two Intersecting Logical Or</li>
+        <li><span class="unicode">&#x2A57</span><span class="text">⩗</span><span class="name">Sloping Large Or</li>
+        <li><span class="unicode">&#x2A58</span><span class="text">⩘</span><span class="name">Sloping Large And</li>
+        <li><span class="unicode">&#x2A59</span><span class="text">⩙</span><span class="name">Logical or Overlapping Logical And</li>
+        <li><span class="unicode">&#x2A5A</span><span class="text">⩚</span><span class="name">Logical and with Middle Stem</li>
+        <li><span class="unicode">&#x2A5B</span><span class="text">⩛</span><span class="name">Logical or with Middle Stem</li>
+        <li><span class="unicode">&#x2A5C</span><span class="text">⩜</span><span class="name">Logical and with Horizontal Dash</li>
+        <li><span class="unicode">&#x2A5D</span><span class="text">⩝</span><span class="name">Logical or with Horizontal Dash</li>
+        <li><span class="unicode">&#x2A5E</span><span class="text">⩞</span><span class="name">Logical and with Double Overbar</li>
+        <li><span class="unicode">&#x2A5F</span><span class="text">⩟</span><span class="name">Logical and with Underbar</li>
+        <li><span class="unicode">&#x2A60</span><span class="text">⩠</span><span class="name">Logical and with Double Underbar</li>
+        <li><span class="unicode">&#x2A61</span><span class="text">⩡</span><span class="name">Small Vee with Underbar</li>
+        <li><span class="unicode">&#x2A62</span><span class="text">⩢</span><span class="name">Logical or with Double Overbar</li>
+        <li><span class="unicode">&#x2A63</span><span class="text">⩣</span><span class="name">Logical or with Double Underbar</li>
+        <li><span class="unicode">&#x2A64</span><span class="text">⩤</span><span class="name">Z Notation Domain Antirestriction</li>
+        <li><span class="unicode">&#x2A65</span><span class="text">⩥</span><span class="name">Z Notation Range Antirestriction</li>
+        <li><span class="unicode">&#x2A66</span><span class="text">⩦</span><span class="name">Equals Sign with Dot Below</li>
+        <li><span class="unicode">&#x2A67</span><span class="text">⩧</span><span class="name">Identical with Dot Above</li>
+        <li><span class="unicode">&#x2A68</span><span class="text">⩨</span><span class="name">Triple Horizontal Bar with Double Vertical Stroke</li>
+        <li><span class="unicode">&#x2A69</span><span class="text">⩩</span><span class="name">Triple Horizontal Bar with Triple Vertical Stroke</li>
+        <li><span class="unicode">&#x2A6A</span><span class="text">⩪</span><span class="name">Tilde Operator with Dot Above</li>
+        <li><span class="unicode">&#x2A6B</span><span class="text">⩫</span><span class="name">Tilde Operator with Rising Dots</li>
+        <li><span class="unicode">&#x2A6C</span><span class="text">⩬</span><span class="name">Similar Minus Similar</li>
+        <li><span class="unicode">&#x2A6D</span><span class="text">⩭</span><span class="name">Congruent with Dot Above</li>
+        <li><span class="unicode">&#x2A6E</span><span class="text">⩮</span><span class="name">Equals with Asterisk</li>
+        <li><span class="unicode">&#x2A6F</span><span class="text">⩯</span><span class="name">Almost Equal to with Circumflex Accent</li>
+        <li><span class="unicode">&#x2A70</span><span class="text">⩰</span><span class="name">Approximately Equal or Equal To</li>
+        <li><span class="unicode">&#x2A71</span><span class="text">⩱</span><span class="name">Equals Sign Above Plus Sign</li>
+        <li><span class="unicode">&#x2A72</span><span class="text">⩲</span><span class="name">Plus Sign Above Equals Sign</li>
+        <li><span class="unicode">&#x2A73</span><span class="text">⩳</span><span class="name">Equals Sign Above Tilde Operator</li>
+        <li><span class="unicode">&#x2A74</span><span class="text">⩴</span><span class="name">Double Colon Equal</li>
+        <li><span class="unicode">&#x2A75</span><span class="text">⩵</span><span class="name">Two Consecutive Equals Signs</li>
+        <li><span class="unicode">&#x2A76</span><span class="text">⩶</span><span class="name">Three Consecutive Equals Signs</li>
+        <li><span class="unicode">&#x2A77</span><span class="text">⩷</span><span class="name">Equals Sign with Two Dots Above and Two Dots Below</li>
+        <li><span class="unicode">&#x2A78</span><span class="text">⩸</span><span class="name">Equivalent with Four Dots Above</li>
+        <li><span class="unicode">&#x2A79</span><span class="text">⩹</span><span class="name">Less-Than with Circle Inside</li>
+        <li><span class="unicode">&#x2A7A</span><span class="text">⩺</span><span class="name">Greater-Than with Circle Inside</li>
+        <li><span class="unicode">&#x2A7B</span><span class="text">⩻</span><span class="name">Less-Than with Question Mark Above</li>
+        <li><span class="unicode">&#x2A7C</span><span class="text">⩼</span><span class="name">Greater-Than with Question Mark Above</li>
+        <li><span class="unicode">&#x2A7D</span><span class="text">⩽</span><span class="name">Less-Than or Slanted Equal To</li>
+        <li><span class="unicode">&#x2A7E</span><span class="text">⩾</span><span class="name">Greater-Than or Slanted Equal To</li>
+        <li><span class="unicode">&#x2A7F</span><span class="text">⩿</span><span class="name">Less-Than or Slanted Equal to with Dot Inside</li>
+        <li><span class="unicode">&#x2A80</span><span class="text">⪀</span><span class="name">Greater-Than or Slanted Equal to with Dot Inside</li>
+        <li><span class="unicode">&#x2A81</span><span class="text">⪁</span><span class="name">Less-Than or Slanted Equal to with Dot Above</li>
+        <li><span class="unicode">&#x2A82</span><span class="text">⪂</span><span class="name">Greater-Than or Slanted Equal to with Dot Above</li>
+        <li><span class="unicode">&#x2A83</span><span class="text">⪃</span><span class="name">Less-Than or Slanted Equal to with Dot Above Right</li>
+        <li><span class="unicode">&#x2A84</span><span class="text">⪄</span><span class="name">Greater-Than or Slanted Equal to with Dot Above Left</li>
+        <li><span class="unicode">&#x2A85</span><span class="text">⪅</span><span class="name">Less-Than or Approximate</li>
+        <li><span class="unicode">&#x2A86</span><span class="text">⪆</span><span class="name">Greater-Than or Approximate</li>
+        <li><span class="unicode">&#x2A87</span><span class="text">⪇</span><span class="name">Less-Than and Single-Line Not Equal To</li>
+        <li><span class="unicode">&#x2A88</span><span class="text">⪈</span><span class="name">Greater-Than and Single-Line Not Equal To</li>
+        <li><span class="unicode">&#x2A89</span><span class="text">⪉</span><span class="name">Less-Than and Not Approximate</li>
+        <li><span class="unicode">&#x2A8A</span><span class="text">⪊</span><span class="name">Greater-Than and Not Approximate</li>
+        <li><span class="unicode">&#x2A8B</span><span class="text">⪋</span><span class="name">Less-Than Above Double-Line Equal Above Greater-Than</li>
+        <li><span class="unicode">&#x2A8C</span><span class="text">⪌</span><span class="name">Greater-Than Above Double-Line Equal Above Less-Than</li>
+        <li><span class="unicode">&#x2A8D</span><span class="text">⪍</span><span class="name">Less-Than Above Similar or Equal</li>
+        <li><span class="unicode">&#x2A8E</span><span class="text">⪎</span><span class="name">Greater-Than Above Similar or Equal</li>
+        <li><span class="unicode">&#x2A8F</span><span class="text">⪏</span><span class="name">Less-Than Above Similar Above Greater-Than</li>
+        <li><span class="unicode">&#x2A90</span><span class="text">⪐</span><span class="name">Greater-Than Above Similar Above Less-Than</li>
+        <li><span class="unicode">&#x2A91</span><span class="text">⪑</span><span class="name">Less-Than Above Greater-Than Above Double-Line Equal</li>
+        <li><span class="unicode">&#x2A92</span><span class="text">⪒</span><span class="name">Greater-Than Above Less-Than Above Double-Line Equal</li>
+        <li><span class="unicode">&#x2A93</span><span class="text">⪓</span><span class="name">Less-Than Above Slanted Equal Above Greater-Than Above Slanted Equal</li>
+        <li><span class="unicode">&#x2A94</span><span class="text">⪔</span><span class="name">Greater-Than Above Slanted Equal Above Less-Than Above Slanted Equal</li>
+        <li><span class="unicode">&#x2A95</span><span class="text">⪕</span><span class="name">Slanted Equal to or Less-Than</li>
+        <li><span class="unicode">&#x2A96</span><span class="text">⪖</span><span class="name">Slanted Equal to or Greater-Than</li>
+        <li><span class="unicode">&#x2A97</span><span class="text">⪗</span><span class="name">Slanted Equal to or Less-Than with Dot Inside</li>
+        <li><span class="unicode">&#x2A98</span><span class="text">⪘</span><span class="name">Slanted Equal to or Greater-Than with Dot Inside</li>
+        <li><span class="unicode">&#x2A99</span><span class="text">⪙</span><span class="name">Double-Line Equal to or Less-Than</li>
+        <li><span class="unicode">&#x2A9A</span><span class="text">⪚</span><span class="name">Double-Line Equal to or Greater-Than</li>
+        <li><span class="unicode">&#x2A9B</span><span class="text">⪛</span><span class="name">Double-Line Slanted Equal to or Less-Than</li>
+        <li><span class="unicode">&#x2A9C</span><span class="text">⪜</span><span class="name">Double-Line Slanted Equal to or Greater-Than</li>
+        <li><span class="unicode">&#x2A9D</span><span class="text">⪝</span><span class="name">Similar or Less-Than</li>
+        <li><span class="unicode">&#x2A9E</span><span class="text">⪞</span><span class="name">Similar or Greater-Than</li>
+        <li><span class="unicode">&#x2A9F</span><span class="text">⪟</span><span class="name">Similar Above Less-Than Above Equals Sign</li>
+        <li><span class="unicode">&#x2AA0</span><span class="text">⪠</span><span class="name">Similar Above Greater-Than Above Equals Sign</li>
+        <li><span class="unicode">&#x2AA1</span><span class="text">⪡</span><span class="name">Double Nested Less-Than</li>
+        <li><span class="unicode">&#x2AA2</span><span class="text">⪢</span><span class="name">Double Nested Greater-Than</li>
+        <li><span class="unicode">&#x2AA3</span><span class="text">⪣</span><span class="name">Double Nested Less-Than with Underbar</li>
+        <li><span class="unicode">&#x2AA4</span><span class="text">⪤</span><span class="name">Greater-Than Overlapping Less-Than</li>
+        <li><span class="unicode">&#x2AA5</span><span class="text">⪥</span><span class="name">Greater-Than Beside Less-Than</li>
+        <li><span class="unicode">&#x2AA6</span><span class="text">⪦</span><span class="name">Less-Than Closed By Curve</li>
+        <li><span class="unicode">&#x2AA7</span><span class="text">⪧</span><span class="name">Greater-Than Closed By Curve</li>
+        <li><span class="unicode">&#x2AA8</span><span class="text">⪨</span><span class="name">Less-Than Closed By Curve Above Slanted Equal</li>
+        <li><span class="unicode">&#x2AA9</span><span class="text">⪩</span><span class="name">Greater-Than Closed By Curve Above Slanted Equal</li>
+        <li><span class="unicode">&#x2AAA</span><span class="text">⪪</span><span class="name">Smaller Than</li>
+        <li><span class="unicode">&#x2AAB</span><span class="text">⪫</span><span class="name">Larger Than</li>
+        <li><span class="unicode">&#x2AAC</span><span class="text">⪬</span><span class="name">Smaller Than or Equal To</li>
+        <li><span class="unicode">&#x2AAD</span><span class="text">⪭</span><span class="name">Larger Than or Equal To</li>
+        <li><span class="unicode">&#x2AAE</span><span class="text">⪮</span><span class="name">Equals Sign with Bumpy Above</li>
+        <li><span class="unicode">&#x2AAF</span><span class="text">⪯</span><span class="name">Precedes Above Single-Line Equals Sign</li>
+        <li><span class="unicode">&#x2AB0</span><span class="text">⪰</span><span class="name">Succeeds Above Single-Line Equals Sign</li>
+        <li><span class="unicode">&#x2AB1</span><span class="text">⪱</span><span class="name">Precedes Above Single-Line Not Equal To</li>
+        <li><span class="unicode">&#x2AB2</span><span class="text">⪲</span><span class="name">Succeeds Above Single-Line Not Equal To</li>
+        <li><span class="unicode">&#x2AB3</span><span class="text">⪳</span><span class="name">Precedes Above Equals Sign</li>
+        <li><span class="unicode">&#x2AB4</span><span class="text">⪴</span><span class="name">Succeeds Above Equals Sign</li>
+        <li><span class="unicode">&#x2AB5</span><span class="text">⪵</span><span class="name">Precedes Above Not Equal To</li>
+        <li><span class="unicode">&#x2AB6</span><span class="text">⪶</span><span class="name">Succeeds Above Not Equal To</li>
+        <li><span class="unicode">&#x2AB7</span><span class="text">⪷</span><span class="name">Precedes Above Almost Equal To</li>
+        <li><span class="unicode">&#x2AB8</span><span class="text">⪸</span><span class="name">Succeeds Above Almost Equal To</li>
+        <li><span class="unicode">&#x2AB9</span><span class="text">⪹</span><span class="name">Precedes Above Not Almost Equal To</li>
+        <li><span class="unicode">&#x2ABA</span><span class="text">⪺</span><span class="name">Succeeds Above Not Almost Equal To</li>
+        <li><span class="unicode">&#x2ABB</span><span class="text">⪻</span><span class="name">Double Precedes</li>
+        <li><span class="unicode">&#x2ABC</span><span class="text">⪼</span><span class="name">Double Succeeds</li>
+        <li><span class="unicode">&#x2ABD</span><span class="text">⪽</span><span class="name">Subset with Dot</li>
+        <li><span class="unicode">&#x2ABE</span><span class="text">⪾</span><span class="name">Superset with Dot</li>
+        <li><span class="unicode">&#x2ABF</span><span class="text">⪿</span><span class="name">Subset with Plus Sign Below</li>
+        <li><span class="unicode">&#x2AC0</span><span class="text">⫀</span><span class="name">Superset with Plus Sign Below</li>
+        <li><span class="unicode">&#x2AC1</span><span class="text">⫁</span><span class="name">Subset with Multiplication Sign Below</li>
+        <li><span class="unicode">&#x2AC2</span><span class="text">⫂</span><span class="name">Superset with Multiplication Sign Below</li>
+        <li><span class="unicode">&#x2AC3</span><span class="text">⫃</span><span class="name">Subset of or Equal to with Dot Above</li>
+        <li><span class="unicode">&#x2AC4</span><span class="text">⫄</span><span class="name">Superset of or Equal to with Dot Above</li>
+        <li><span class="unicode">&#x2AC5</span><span class="text">⫅</span><span class="name">Subset of Above Equals Sign</li>
+        <li><span class="unicode">&#x2AC6</span><span class="text">⫆</span><span class="name">Superset of Above Equals Sign</li>
+        <li><span class="unicode">&#x2AC7</span><span class="text">⫇</span><span class="name">Subset of Above Tilde Operator</li>
+        <li><span class="unicode">&#x2AC8</span><span class="text">⫈</span><span class="name">Superset of Above Tilde Operator</li>
+        <li><span class="unicode">&#x2AC9</span><span class="text">⫉</span><span class="name">Subset of Above Almost Equal To</li>
+        <li><span class="unicode">&#x2ACA</span><span class="text">⫊</span><span class="name">Superset of Above Almost Equal To</li>
+        <li><span class="unicode">&#x2ACB</span><span class="text">⫋</span><span class="name">Subset of Above Not Equal To</li>
+        <li><span class="unicode">&#x2ACC</span><span class="text">⫌</span><span class="name">Superset of Above Not Equal To</li>
+        <li><span class="unicode">&#x2ACD</span><span class="text">⫍</span><span class="name">Square Left Open Box Operator</li>
+        <li><span class="unicode">&#x2ACE</span><span class="text">⫎</span><span class="name">Square Right Open Box Operator</li>
+        <li><span class="unicode">&#x2ACF</span><span class="text">⫏</span><span class="name">Closed Subset</li>
+        <li><span class="unicode">&#x2AD0</span><span class="text">⫐</span><span class="name">Closed Superset</li>
+        <li><span class="unicode">&#x2AD1</span><span class="text">⫑</span><span class="name">Closed Subset or Equal To</li>
+        <li><span class="unicode">&#x2AD2</span><span class="text">⫒</span><span class="name">Closed Superset or Equal To</li>
+        <li><span class="unicode">&#x2AD3</span><span class="text">⫓</span><span class="name">Subset Above Superset</li>
+        <li><span class="unicode">&#x2AD4</span><span class="text">⫔</span><span class="name">Superset Above Subset</li>
+        <li><span class="unicode">&#x2AD5</span><span class="text">⫕</span><span class="name">Subset Above Subset</li>
+        <li><span class="unicode">&#x2AD6</span><span class="text">⫖</span><span class="name">Superset Above Superset</li>
+        <li><span class="unicode">&#x2AD7</span><span class="text">⫗</span><span class="name">Superset Beside Subset</li>
+        <li><span class="unicode">&#x2AD8</span><span class="text">⫘</span><span class="name">Superset Beside and Joined By Dash with Subset</li>
+        <li><span class="unicode">&#x2AD9</span><span class="text">⫙</span><span class="name">Element of Opening Downwards</li>
+        <li><span class="unicode">&#x2ADA</span><span class="text">⫚</span><span class="name">Pitchfork with Tee Top</li>
+        <li><span class="unicode">&#x2ADB</span><span class="text">⫛</span><span class="name">Transversal Intersection</li>
+        <li><span class="unicode">&#x2ADC</span><span class="text">⫝̸</span><span class="name">Forking</li>
+        <li><span class="unicode">&#x2ADD</span><span class="text">⫝</span><span class="name">Nonforking</li>
+        <li><span class="unicode">&#x2ADE</span><span class="text">⫞</span><span class="name">Short Left Tack</li>
+        <li><span class="unicode">&#x2ADF</span><span class="text">⫟</span><span class="name">Short Down Tack</li>
+        <li><span class="unicode">&#x2AE0</span><span class="text">⫠</span><span class="name">Short Up Tack</li>
+        <li><span class="unicode">&#x2AE1</span><span class="text">⫡</span><span class="name">Perpendicular with S</li>
+        <li><span class="unicode">&#x2AE2</span><span class="text">⫢</span><span class="name">Vertical Bar Triple Right Turnstile</li>
+        <li><span class="unicode">&#x2AE3</span><span class="text">⫣</span><span class="name">Double Vertical Bar Left Turnstile</li>
+        <li><span class="unicode">&#x2AE4</span><span class="text">⫤</span><span class="name">Vertical Bar Double Left Turnstile</li>
+        <li><span class="unicode">&#x2AE5</span><span class="text">⫥</span><span class="name">Double Vertical Bar Double Left Turnstile</li>
+        <li><span class="unicode">&#x2AE6</span><span class="text">⫦</span><span class="name">Long Dash from Left Member of Double Vertical</li>
+        <li><span class="unicode">&#x2AE7</span><span class="text">⫧</span><span class="name">Short Down Tack with Overbar</li>
+        <li><span class="unicode">&#x2AE8</span><span class="text">⫨</span><span class="name">Short Up Tack with Underbar</li>
+        <li><span class="unicode">&#x2AE9</span><span class="text">⫩</span><span class="name">Short Up Tack Above Short Down Tack</li>
+        <li><span class="unicode">&#x2AEA</span><span class="text">⫪</span><span class="name">Double Down Tack</li>
+        <li><span class="unicode">&#x2AEB</span><span class="text">⫫</span><span class="name">Double Up Tack</li>
+        <li><span class="unicode">&#x2AEC</span><span class="text">⫬</span><span class="name">Double Stroke Not Sign</li>
+        <li><span class="unicode">&#x2AED</span><span class="text">⫭</span><span class="name">Reversed Double Stroke Not Sign</li>
+        <li><span class="unicode">&#x2AEE</span><span class="text">⫮</span><span class="name">Does Not Divide with Reversed Negation Slash</li>
+        <li><span class="unicode">&#x2AEF</span><span class="text">⫯</span><span class="name">Vertical Line with Circle Above</li>
+        <li><span class="unicode">&#x2AF0</span><span class="text">⫰</span><span class="name">Vertical Line with Circle Below</li>
+        <li><span class="unicode">&#x2AF1</span><span class="text">⫱</span><span class="name">Down Tack with Circle Below</li>
+        <li><span class="unicode">&#x2AF2</span><span class="text">⫲</span><span class="name">Parallel with Horizontal Stroke</li>
+        <li><span class="unicode">&#x2AF3</span><span class="text">⫳</span><span class="name">Parallel with Tilde Operator</li>
+        <li><span class="unicode">&#x2AF4</span><span class="text">⫴</span><span class="name">Triple Vertical Bar Binary Relation</li>
+        <li><span class="unicode">&#x2AF5</span><span class="text">⫵</span><span class="name">Triple Vertical Bar with Horizontal Stroke</li>
+        <li><span class="unicode">&#x2AF6</span><span class="text">⫶</span><span class="name">Triple Colon Operator</li>
+        <li><span class="unicode">&#x2AF7</span><span class="text">⫷</span><span class="name">Triple Nested Less-Than</li>
+        <li><span class="unicode">&#x2AF8</span><span class="text">⫸</span><span class="name">Triple Nested Greater-Than</li>
+        <li><span class="unicode">&#x2AF9</span><span class="text">⫹</span><span class="name">Double-Line Slanted Less-Than or Equal To</li>
+        <li><span class="unicode">&#x2AFA</span><span class="text">⫺</span><span class="name">Double-Line Slanted Greater-Than or Equal To</li>
+        <li><span class="unicode">&#x2AFB</span><span class="text">⫻</span><span class="name">Triple Solidus Binary Relation</li>
+        <li><span class="unicode">&#x2AFC</span><span class="text">⫼</span><span class="name">Large Triple Vertical Bar Operator</li>
+        <li><span class="unicode">&#x2AFD</span><span class="text">⫽</span><span class="name">Double Solidus Operator</li>
+        <li><span class="unicode">&#x2AFE</span><span class="text">⫾</span><span class="name">White Vertical Bar</li>
+        <li><span class="unicode">&#x2AFF</span><span class="text">⫿</span><span class="name">N-Ary White Vertical Bar</li>
+        <li><span class="unicode">&#x2B30</span><span class="text">⬰</span><span class="name">Left Arrow with Small Circle</li>
+        <li><span class="unicode">&#x2B31</span><span class="text">⬱</span><span class="name">Three Leftwards Arrows</li>
+        <li><span class="unicode">&#x2B32</span><span class="text">⬲</span><span class="name">Left Arrow with Circled Plus</li>
+        <li><span class="unicode">&#x2B33</span><span class="text">⬳</span><span class="name">Long Leftwards Squiggle Arrow</li>
+        <li><span class="unicode">&#x2B34</span><span class="text">⬴</span><span class="name">Leftwards Two-Headed Arrow with Vertical Stroke</li>
+        <li><span class="unicode">&#x2B35</span><span class="text">⬵</span><span class="name">Leftwards Two-Headed Arrow with Double Vertical Stroke</li>
+        <li><span class="unicode">&#x2B36</span><span class="text">⬶</span><span class="name">Leftwards Two-Headed Arrow from Bar</li>
+        <li><span class="unicode">&#x2B37</span><span class="text">⬷</span><span class="name">Leftwards Two-Headed Triple Dash Arrow</li>
+        <li><span class="unicode">&#x2B38</span><span class="text">⬸</span><span class="name">Leftwards Arrow with Dotted Stem</li>
+        <li><span class="unicode">&#x2B39</span><span class="text">⬹</span><span class="name">Leftwards Arrow with Tail with Vertical Stroke</li>
+        <li><span class="unicode">&#x2B3A</span><span class="text">⬺</span><span class="name">Leftwards Arrow with Tail with Double Vertical Stroke</li>
+        <li><span class="unicode">&#x2B3B</span><span class="text">⬻</span><span class="name">Leftwards Two-Headed Arrow with Tail</li>
+        <li><span class="unicode">&#x2B3C</span><span class="text">⬼</span><span class="name">Leftwards Two-Headed Arrow with Tail with Vertical Stroke</li>
+        <li><span class="unicode">&#x2B3D</span><span class="text">⬽</span><span class="name">Leftwards Two-Headed Arrow with Tail with Double Vertical Stroke</li>
+        <li><span class="unicode">&#x2B3E</span><span class="text">⬾</span><span class="name">Leftwards Arrow Through X</li>
+        <li><span class="unicode">&#x2B3F</span><span class="text">⬿</span><span class="name">Wave Arrow Pointing Directly Left</li>
+        <li><span class="unicode">&#x2B40</span><span class="text">⭀</span><span class="name">Equals Sign Above Leftwards Arrow</li>
+        <li><span class="unicode">&#x2B41</span><span class="text">⭁</span><span class="name">Reverse Tilde Operator Above Leftwards Arrow</li>
+        <li><span class="unicode">&#x2B42</span><span class="text">⭂</span><span class="name">Leftwards Arrow Above Reverse Almost Equal To</li>
+        <li><span class="unicode">&#x2B43</span><span class="text">⭃</span><span class="name">Rightwards Arrow Through Greater-Than</li>
+        <li><span class="unicode">&#x2B44</span><span class="text">⭄</span><span class="name">Rightwards Arrow Through Superset</li>
+        <li><span class="unicode">&#x2B47</span><span class="text">⭇</span><span class="name">Reverse Tilde Operator Above Rightwards Arrow</li>
+        <li><span class="unicode">&#x2B48</span><span class="text">⭈</span><span class="name">Rightwards Arrow Above Reverse Almost Equal To</li>
+        <li><span class="unicode">&#x2B49</span><span class="text">⭉</span><span class="name">Tilde Operator Above Leftwards Arrow</li>
+        <li><span class="unicode">&#x2B4A</span><span class="text">⭊</span><span class="name">Leftwards Arrow Above Almost Equal To</li>
+        <li><span class="unicode">&#x2B4B</span><span class="text">⭋</span><span class="name">Leftwards Arrow Above Reverse Tilde Operator</li>
+        <li><span class="unicode">&#x2B4C</span><span class="text">⭌</span><span class="name">Rightwards Arrow Above Reverse Tilde Operator</li>
+        <li><span class="unicode">&#xFB29</span><span class="text">﬩</span><span class="name">Hebrew Letter Alternative Plus Sign</li>
+        <li><span class="unicode">&#xFE62</span><span class="text">﹢</span><span class="name">Small Plus Sign</li>
+        <li><span class="unicode">&#xFE64</span><span class="text">﹤</span><span class="name">Small Less-Than Sign</li>
+        <li><span class="unicode">&#xFE65</span><span class="text">﹥</span><span class="name">Small Greater-Than Sign</li>
+        <li><span class="unicode">&#xFE66</span><span class="text">﹦</span><span class="name">Small Equals Sign</li>
+        <li><span class="unicode">&#xFF0B</span><span class="text">＋</span><span class="name">Fullwidth Plus Sign</li>
+        <li><span class="unicode">&#xFF1C</span><span class="text">＜</span><span class="name">Fullwidth Less-Than Sign</li>
+        <li><span class="unicode">&#xFF1D</span><span class="text">＝</span><span class="name">Fullwidth Equals Sign</li>
+        <li><span class="unicode">&#xFF1E</span><span class="text">＞</span><span class="name">Fullwidth Greater-Than Sign</li>
+        <li><span class="unicode">&#xFF5C</span><span class="text">｜</span><span class="name">Fullwidth Vertical Line</li>
+        <li><span class="unicode">&#xFF5E</span><span class="text">～</span><span class="name">Fullwidth Tilde</li>
+        <li><span class="unicode">&#xFFE2</span><span class="text">￢</span><span class="name">Fullwidth Not Sign</li>
+        <li><span class="unicode">&#xFFE9</span><span class="text">￩</span><span class="name">Halfwidth Leftwards Arrow</li>
+        <li><span class="unicode">&#xFFEA</span><span class="text">￪</span><span class="name">Halfwidth Upwards Arrow</li>
+        <li><span class="unicode">&#xFFEB</span><span class="text">￫</span><span class="name">Halfwidth Rightwards Arrow</li>
+        <li><span class="unicode">&#xFFEC</span><span class="text">￬</span><span class="name">Halfwidth Downwards Arrow</li>
+        <li><span class="unicode">&#x1D6C1</span><span class="text">𝛁</span><span class="name">Mathematical Bold Nabla</li>
+        <li><span class="unicode">&#x1D6DB</span><span class="text">𝛛</span><span class="name">Mathematical Bold Partial Differential</li>
+        <li><span class="unicode">&#x1D6FB</span><span class="text">𝛻</span><span class="name">Mathematical Italic Nabla</li>
+        <li><span class="unicode">&#x1D715</span><span class="text">𝜕</span><span class="name">Mathematical Italic Partial Differential</li>
+        <li><span class="unicode">&#x1D735</span><span class="text">𝜵</span><span class="name">Mathematical Bold Italic Nabla</li>
+        <li><span class="unicode">&#x1D74F</span><span class="text">𝝏</span><span class="name">Mathematical Bold Italic Partial Differential</li>
+        <li><span class="unicode">&#x1D76F</span><span class="text">𝝯</span><span class="name">Mathematical Sans-Serif Bold Nabla</li>
+        <li><span class="unicode">&#x1D789</span><span class="text">𝞉</span><span class="name">Mathematical Sans-Serif Bold Partial Differential</li>
+        <li><span class="unicode">&#x1D7A9</span><span class="text">𝞩</span><span class="name">Mathematical Sans-Serif Bold Italic Nabla</li>
+        <li><span class="unicode">&#x1D7C3</span><span class="text">𝟃</span><span class="name">Mathematical Sans-Serif Bold Italic Partial Differential</li>
+        <li><span class="unicode">&#x1EEF0</span><span class="text">𞻰</span><span class="name">Arabic Mathematical Operator Meem with Hah with Tatweel</li>
+        <li><span class="unicode">&#x1EEF1</span><span class="text">𞻱</span><span class="name">Arabic Mathematical Operator Hah with Dal        
 	</ul>
   </body>
 </html>

--- a/symbols-list/math-role-UTF8-list.html
+++ b/symbols-list/math-role-UTF8-list.html
@@ -1,0 +1,973 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en">
+	<head>
+		<title>List of UTF-8 Math symbols with ARIA math role</title>
+		<style>p.formula {
+				text-align: center;
+			}
+			math {
+				display:block math;
+			}</style>
+	</head>
+	<body>
+		<h1>List of UTF-8 Math symbols with ARIA math role</h1>
+		<p>
+			We developed these tests to help identify how the ARIA
+			<code>math</code>
+			role is interpreted by assistive technologies 
+		</p>
+		<p>
+			Each line contains the unicode with role math followed up by the symbol in text and the name of the symbol. 
+		</p>
+		<ul>
+      <li><span class="unicode" role="math">&#x002B</span><span class="text">+</span><span class="name">Plus Sign</li>
+        <li><span class="unicode" role="math">&#x003C</span><span class="text"><</span><span class="name">Less-Than Sign</li>
+        <li><span class="unicode" role="math">&#x003D</span><span class="text">=</span><span class="name">Equals Sign</li>
+        <li><span class="unicode" role="math">&#x003E</span><span class="text">></span><span class="name">Greater-Than Sign</li>
+        <li><span class="unicode" role="math">&#x007C</span><span class="text">|</span><span class="name">Vertical Line</li>
+        <li><span class="unicode" role="math">&#x007E</span><span class="text">~</span><span class="name">Tilde</li>
+        <li><span class="unicode" role="math">&#x00AC</span><span class="text">¬</span><span class="name">Not Sign</li>
+        <li><span class="unicode" role="math">&#x00B1</span><span class="text">±</span><span class="name">Plus-Minus Sign</li>
+        <li><span class="unicode" role="math">&#x00D7</span><span class="text">×</span><span class="name">Multiplication Sign</li>
+        <li><span class="unicode" role="math">&#x00F7</span><span class="text">÷</span><span class="name">Division Sign</li>
+        <li><span class="unicode" role="math">&#x03F6</span><span class="text">϶</span><span class="name">Greek Reversed Lunate Epsilon Symbol</li>
+        <li><span class="unicode" role="math">&#x0606</span><span class="text">؆</span><span class="name">Arabic-Indic Cube Root</li>
+        <li><span class="unicode" role="math">&#x0607</span><span class="text">؇</span><span class="name">Arabic-Indic Fourth Root</li>
+        <li><span class="unicode" role="math">&#x0608</span><span class="text">؈</span><span class="name">Arabic Ray</li>
+        <li><span class="unicode" role="math">&#x2044</span><span class="text">⁄</span><span class="name">Fraction Slash</li>
+        <li><span class="unicode" role="math">&#x2052</span><span class="text">⁒</span><span class="name">Commercial Minus Sign</li>
+        <li><span class="unicode" role="math">&#x207A</span><span class="text">⁺</span><span class="name">Superscript Plus Sign</li>
+        <li><span class="unicode" role="math">&#x207B</span><span class="text">⁻</span><span class="name">Superscript Minus</li>
+        <li><span class="unicode" role="math">&#x207C</span><span class="text">⁼</span><span class="name">Superscript Equals Sign</li>
+        <li><span class="unicode" role="math">&#x208A</span><span class="text">₊</span><span class="name">Subscript Plus Sign</li>
+        <li><span class="unicode" role="math">&#x208B</span><span class="text">₋</span><span class="name">Subscript Minus</li>
+        <li><span class="unicode" role="math">&#x208C</span><span class="text">₌</span><span class="name">Subscript Equals Sign</li>
+        <li><span class="unicode" role="math">&#x2118</span><span class="text">℘</span><span class="name">Script Capital P</li>
+        <li><span class="unicode" role="math">&#x2140</span><span class="text">⅀</span><span class="name">Double-Struck N-Ary Summation</li>
+        <li><span class="unicode" role="math">&#x2141</span><span class="text">⅁</span><span class="name">Turned Sans-Serif Capital G</li>
+        <li><span class="unicode" role="math">&#x2142</span><span class="text">⅂</span><span class="name">Turned Sans-Serif Capital L</li>
+        <li><span class="unicode" role="math">&#x2143</span><span class="text">⅃</span><span class="name">Reversed Sans-Serif Capital L</li>
+        <li><span class="unicode" role="math">&#x2144</span><span class="text">⅄</span><span class="name">Turned Sans-Serif Capital Y</li>
+        <li><span class="unicode" role="math">&#x214B</span><span class="text">⅋</span><span class="name">Turned Ampersand</li>
+        <li><span class="unicode" role="math">&#x2190</span><span class="text">←</span><span class="name">Leftwards Arrow</li>
+        <li><span class="unicode" role="math">&#x2191</span><span class="text">↑</span><span class="name">Upwards Arrow</li>
+        <li><span class="unicode" role="math">&#x2192</span><span class="text">→</span><span class="name">Rightwards Arrow</li>
+        <li><span class="unicode" role="math">&#x2193</span><span class="text">↓</span><span class="name">Downwards Arrow</li>
+        <li><span class="unicode" role="math">&#x2194</span><span class="text">↔</span><span class="name">Left Right Arrow</li>
+        <li><span class="unicode" role="math">&#x219A</span><span class="text">↚</span><span class="name">Leftwards Arrow with Stroke</li>
+        <li><span class="unicode" role="math">&#x219B</span><span class="text">↛</span><span class="name">Rightwards Arrow with Stroke</li>
+        <li><span class="unicode" role="math">&#x21A0</span><span class="text">↠</span><span class="name">Rightwards Two Headed Arrow</li>
+        <li><span class="unicode" role="math">&#x21A3</span><span class="text">↣</span><span class="name">Rightwards Arrow with Tail</li>
+        <li><span class="unicode" role="math">&#x21A6</span><span class="text">↦</span><span class="name">Rightwards Arrow from Bar</li>
+        <li><span class="unicode" role="math">&#x21AE</span><span class="text">↮</span><span class="name">Left Right Arrow with Stroke</li>
+        <li><span class="unicode" role="math">&#x21CE</span><span class="text">⇎</span><span class="name">Left Right Double Arrow with Stroke</li>
+        <li><span class="unicode" role="math">&#x21CF</span><span class="text">⇏</span><span class="name">Rightwards Double Arrow with Stroke</li>
+        <li><span class="unicode" role="math">&#x21D2</span><span class="text">⇒</span><span class="name">Rightwards Double Arrow</li>
+        <li><span class="unicode" role="math">&#x21D4</span><span class="text">⇔</span><span class="name">Left Right Double Arrow</li>
+        <li><span class="unicode" role="math">&#x21F4</span><span class="text">⇴</span><span class="name">Right Arrow with Small Circle</li>
+        <li><span class="unicode" role="math">&#x21F5</span><span class="text">⇵</span><span class="name">Downwards Arrow Leftwards of Upwards Arrow</li>
+        <li><span class="unicode" role="math">&#x21F6</span><span class="text">⇶</span><span class="name">Three Rightwards Arrows</li>
+        <li><span class="unicode" role="math">&#x21F7</span><span class="text">⇷</span><span class="name">Leftwards Arrow with Vertical Stroke</li>
+        <li><span class="unicode" role="math">&#x21F8</span><span class="text">⇸</span><span class="name">Rightwards Arrow with Vertical Stroke</li>
+        <li><span class="unicode" role="math">&#x21F9</span><span class="text">⇹</span><span class="name">Left Right Arrow with Vertical Stroke</li>
+        <li><span class="unicode" role="math">&#x21FA</span><span class="text">⇺</span><span class="name">Leftwards Arrow with Double Vertical Stroke</li>
+        <li><span class="unicode" role="math">&#x21FB</span><span class="text">⇻</span><span class="name">Rightwards Arrow with Double Vertical Stroke</li>
+        <li><span class="unicode" role="math">&#x21FC</span><span class="text">⇼</span><span class="name">Left Right Arrow with Double Vertical Stroke</li>
+        <li><span class="unicode" role="math">&#x21FD</span><span class="text">⇽</span><span class="name">Leftwards Open-Headed Arrow</li>
+        <li><span class="unicode" role="math">&#x21FE</span><span class="text">⇾</span><span class="name">Rightwards Open-Headed Arrow</li>
+        <li><span class="unicode" role="math">&#x21FF</span><span class="text">⇿</span><span class="name">Left Right Open-Headed Arrow</li>
+        <li><span class="unicode" role="math">&#x2200</span><span class="text">∀</span><span class="name">For All</li>
+        <li><span class="unicode" role="math">&#x2201</span><span class="text">∁</span><span class="name">Complement</li>
+        <li><span class="unicode" role="math">&#x2202</span><span class="text">∂</span><span class="name">Partial Differential</li>
+        <li><span class="unicode" role="math">&#x2203</span><span class="text">∃</span><span class="name">There Exists</li>
+        <li><span class="unicode" role="math">&#x2204</span><span class="text">∄</span><span class="name">There Does Not Exist</li>
+        <li><span class="unicode" role="math">&#x2205</span><span class="text">∅</span><span class="name">Empty Set</li>
+        <li><span class="unicode" role="math">&#x2206</span><span class="text">∆</span><span class="name">Increment</li>
+        <li><span class="unicode" role="math">&#x2207</span><span class="text">∇</span><span class="name">Nabla</li>
+        <li><span class="unicode" role="math">&#x2208</span><span class="text">∈</span><span class="name">Element Of</li>
+        <li><span class="unicode" role="math">&#x2209</span><span class="text">∉</span><span class="name">Not An Element Of</li>
+        <li><span class="unicode" role="math">&#x220A</span><span class="text">∊</span><span class="name">Small Element Of</li>
+        <li><span class="unicode" role="math">&#x220B</span><span class="text">∋</span><span class="name">Contains as Member</li>
+        <li><span class="unicode" role="math">&#x220C</span><span class="text">∌</span><span class="name">Does Not Contain as Member</li>
+        <li><span class="unicode" role="math">&#x220D</span><span class="text">∍</span><span class="name">Small Contains as Member</li>
+        <li><span class="unicode" role="math">&#x220E</span><span class="text">∎</span><span class="name">End of Proof</li>
+        <li><span class="unicode" role="math">&#x220F</span><span class="text">∏</span><span class="name">N-Ary Product</li>
+        <li><span class="unicode" role="math">&#x2210</span><span class="text">∐</span><span class="name">N-Ary Coproduct</li>
+        <li><span class="unicode" role="math">&#x2211</span><span class="text">∑</span><span class="name">N-Ary Summation</li>
+        <li><span class="unicode" role="math">&#x2212</span><span class="text">−</span><span class="name">Minus Sign</li>
+        <li><span class="unicode" role="math">&#x2213</span><span class="text">∓</span><span class="name">Minus-or-Plus Sign</li>
+        <li><span class="unicode" role="math">&#x2214</span><span class="text">∔</span><span class="name">Dot Plus</li>
+        <li><span class="unicode" role="math">&#x2215</span><span class="text">∕</span><span class="name">Division Slash</li>
+        <li><span class="unicode" role="math">&#x2216</span><span class="text">∖</span><span class="name">Set Minus</li>
+        <li><span class="unicode" role="math">&#x2217</span><span class="text">∗</span><span class="name">Asterisk Operator</li>
+        <li><span class="unicode" role="math">&#x2218</span><span class="text">∘</span><span class="name">Ring Operator</li>
+        <li><span class="unicode" role="math">&#x2219</span><span class="text">∙</span><span class="name">Bullet Operator</li>
+        <li><span class="unicode" role="math">&#x221A</span><span class="text">√</span><span class="name">Square Root</li>
+        <li><span class="unicode" role="math">&#x221B</span><span class="text">∛</span><span class="name">Cube Root</li>
+        <li><span class="unicode" role="math">&#x221C</span><span class="text">∜</span><span class="name">Fourth Root</li>
+        <li><span class="unicode" role="math">&#x221D</span><span class="text">∝</span><span class="name">Proportional To</li>
+        <li><span class="unicode" role="math">&#x221E</span><span class="text">∞</span><span class="name">Infinity</li>
+        <li><span class="unicode" role="math">&#x221F</span><span class="text">∟</span><span class="name">Right Angle</li>
+        <li><span class="unicode" role="math">&#x2220</span><span class="text">∠</span><span class="name">Angle</li>
+        <li><span class="unicode" role="math">&#x2221</span><span class="text">∡</span><span class="name">Measured Angle</li>
+        <li><span class="unicode" role="math">&#x2222</span><span class="text">∢</span><span class="name">Spherical Angle</li>
+        <li><span class="unicode" role="math">&#x2223</span><span class="text">∣</span><span class="name">Divides</li>
+        <li><span class="unicode" role="math">&#x2224</span><span class="text">∤</span><span class="name">Does Not Divide</li>
+        <li><span class="unicode" role="math">&#x2225</span><span class="text">∥</span><span class="name">Parallel To</li>
+        <li><span class="unicode" role="math">&#x2226</span><span class="text">∦</span><span class="name">Not Parallel To</li>
+        <li><span class="unicode" role="math">&#x2227</span><span class="text">∧</span><span class="name">Logical And</li>
+        <li><span class="unicode" role="math">&#x2228</span><span class="text">∨</span><span class="name">Logical Or</li>
+        <li><span class="unicode" role="math">&#x2229</span><span class="text">∩</span><span class="name">Intersection</li>
+        <li><span class="unicode" role="math">&#x222A</span><span class="text">∪</span><span class="name">Union</li>
+        <li><span class="unicode" role="math">&#x222B</span><span class="text">∫</span><span class="name">Integral</li>
+        <li><span class="unicode" role="math">&#x222C</span><span class="text">∬</span><span class="name">Double Integral</li>
+        <li><span class="unicode" role="math">&#x222D</span><span class="text">∭</span><span class="name">Triple Integral</li>
+        <li><span class="unicode" role="math">&#x222E</span><span class="text">∮</span><span class="name">Contour Integral</li>
+        <li><span class="unicode" role="math">&#x222F</span><span class="text">∯</span><span class="name">Surface Integral</li>
+        <li><span class="unicode" role="math">&#x2230</span><span class="text">∰</span><span class="name">Volume Integral</li>
+        <li><span class="unicode" role="math">&#x2231</span><span class="text">∱</span><span class="name">Clockwise Integral</li>
+        <li><span class="unicode" role="math">&#x2232</span><span class="text">∲</span><span class="name">Clockwise Contour Integral</li>
+        <li><span class="unicode" role="math">&#x2233</span><span class="text">∳</span><span class="name">Anticlockwise Contour Integral</li>
+        <li><span class="unicode" role="math">&#x2234</span><span class="text">∴</span><span class="name">Therefore</li>
+        <li><span class="unicode" role="math">&#x2235</span><span class="text">∵</span><span class="name">Because</li>
+        <li><span class="unicode" role="math">&#x2236</span><span class="text">∶</span><span class="name">Ratio</li>
+        <li><span class="unicode" role="math">&#x2237</span><span class="text">∷</span><span class="name">Proportion</li>
+        <li><span class="unicode" role="math">&#x2238</span><span class="text">∸</span><span class="name">Dot Minus</li>
+        <li><span class="unicode" role="math">&#x2239</span><span class="text">∹</span><span class="name">Excess</li>
+        <li><span class="unicode" role="math">&#x223A</span><span class="text">∺</span><span class="name">Geometric Proportion</li>
+        <li><span class="unicode" role="math">&#x223B</span><span class="text">∻</span><span class="name">Homothetic</li>
+        <li><span class="unicode" role="math">&#x223C</span><span class="text">∼</span><span class="name">Tilde Operator</li>
+        <li><span class="unicode" role="math">&#x223D</span><span class="text">∽</span><span class="name">Reversed Tilde</li>
+        <li><span class="unicode" role="math">&#x223E</span><span class="text">∾</span><span class="name">Inverted Lazy S</li>
+        <li><span class="unicode" role="math">&#x223F</span><span class="text">∿</span><span class="name">Sine Wave</li>
+        <li><span class="unicode" role="math">&#x2240</span><span class="text">≀</span><span class="name">Wreath Product</li>
+        <li><span class="unicode" role="math">&#x2241</span><span class="text">≁</span><span class="name">Not Tilde</li>
+        <li><span class="unicode" role="math">&#x2242</span><span class="text">≂</span><span class="name">Minus Tilde</li>
+        <li><span class="unicode" role="math">&#x2243</span><span class="text">≃</span><span class="name">Asymptotically Equal To</li>
+        <li><span class="unicode" role="math">&#x2244</span><span class="text">≄</span><span class="name">Not Asymptotically Equal To</li>
+        <li><span class="unicode" role="math">&#x2245</span><span class="text">≅</span><span class="name">Approximately Equal To</li>
+        <li><span class="unicode" role="math">&#x2246</span><span class="text">≆</span><span class="name">Approximately But Not Actually Equal To</li>
+        <li><span class="unicode" role="math">&#x2247</span><span class="text">≇</span><span class="name">Neither Approximately Nor Actually Equal To</li>
+        <li><span class="unicode" role="math">&#x2248</span><span class="text">≈</span><span class="name">Almost Equal To</li>
+        <li><span class="unicode" role="math">&#x2249</span><span class="text">≉</span><span class="name">Not Almost Equal To</li>
+        <li><span class="unicode" role="math">&#x224A</span><span class="text">≊</span><span class="name">Almost Equal or Equal To</li>
+        <li><span class="unicode" role="math">&#x224B</span><span class="text">≋</span><span class="name">Triple Tilde</li>
+        <li><span class="unicode" role="math">&#x224C</span><span class="text">≌</span><span class="name">All Equal To</li>
+        <li><span class="unicode" role="math">&#x224D</span><span class="text">≍</span><span class="name">Equivalent To</li>
+        <li><span class="unicode" role="math">&#x224E</span><span class="text">≎</span><span class="name">Geometrically Equivalent To</li>
+        <li><span class="unicode" role="math">&#x224F</span><span class="text">≏</span><span class="name">Difference Between</li>
+        <li><span class="unicode" role="math">&#x2250</span><span class="text">≐</span><span class="name">Approaches the Limit</li>
+        <li><span class="unicode" role="math">&#x2251</span><span class="text">≑</span><span class="name">Geometrically Equal To</li>
+        <li><span class="unicode" role="math">&#x2252</span><span class="text">≒</span><span class="name">Approximately Equal to or the Image Of</li>
+        <li><span class="unicode" role="math">&#x2253</span><span class="text">≓</span><span class="name">Image of or Approximately Equal To</li>
+        <li><span class="unicode" role="math">&#x2254</span><span class="text">≔</span><span class="name">Colon Equals</li>
+        <li><span class="unicode" role="math">&#x2255</span><span class="text">≕</span><span class="name">Equals Colon</li>
+        <li><span class="unicode" role="math">&#x2256</span><span class="text">≖</span><span class="name">Ring In Equal To</li>
+        <li><span class="unicode" role="math">&#x2257</span><span class="text">≗</span><span class="name">Ring Equal To</li>
+        <li><span class="unicode" role="math">&#x2258</span><span class="text">≘</span><span class="name">Corresponds To</li>
+        <li><span class="unicode" role="math">&#x2259</span><span class="text">≙</span><span class="name">Estimates</li>
+        <li><span class="unicode" role="math">&#x225A</span><span class="text">≚</span><span class="name">Equiangular To</li>
+        <li><span class="unicode" role="math">&#x225B</span><span class="text">≛</span><span class="name">Star Equals</li>
+        <li><span class="unicode" role="math">&#x225C</span><span class="text">≜</span><span class="name">Delta Equal To</li>
+        <li><span class="unicode" role="math">&#x225D</span><span class="text">≝</span><span class="name">Equal to By Definition</li>
+        <li><span class="unicode" role="math">&#x225E</span><span class="text">≞</span><span class="name">Measured By</li>
+        <li><span class="unicode" role="math">&#x225F</span><span class="text">≟</span><span class="name">Questioned Equal To</li>
+        <li><span class="unicode" role="math">&#x2260</span><span class="text">≠</span><span class="name">Not Equal To</li>
+        <li><span class="unicode" role="math">&#x2261</span><span class="text">≡</span><span class="name">Identical To</li>
+        <li><span class="unicode" role="math">&#x2262</span><span class="text">≢</span><span class="name">Not Identical To</li>
+        <li><span class="unicode" role="math">&#x2263</span><span class="text">≣</span><span class="name">Strictly Equivalent To</li>
+        <li><span class="unicode" role="math">&#x2264</span><span class="text">≤</span><span class="name">Less-Than or Equal To</li>
+        <li><span class="unicode" role="math">&#x2265</span><span class="text">≥</span><span class="name">Greater-Than or Equal To</li>
+        <li><span class="unicode" role="math">&#x2266</span><span class="text">≦</span><span class="name">Less-Than Over Equal To</li>
+        <li><span class="unicode" role="math">&#x2267</span><span class="text">≧</span><span class="name">Greater-Than Over Equal To</li>
+        <li><span class="unicode" role="math">&#x2268</span><span class="text">≨</span><span class="name">Less-Than But Not Equal To</li>
+        <li><span class="unicode" role="math">&#x2269</span><span class="text">≩</span><span class="name">Greater-Than But Not Equal To</li>
+        <li><span class="unicode" role="math">&#x226A</span><span class="text">≪</span><span class="name">Much Less-Than</li>
+        <li><span class="unicode" role="math">&#x226B</span><span class="text">≫</span><span class="name">Much Greater-Than</li>
+        <li><span class="unicode" role="math">&#x226C</span><span class="text">≬</span><span class="name">Between</li>
+        <li><span class="unicode" role="math">&#x226D</span><span class="text">≭</span><span class="name">Not Equivalent To</li>
+        <li><span class="unicode" role="math">&#x226E</span><span class="text">≮</span><span class="name">Not Less-Than</li>
+        <li><span class="unicode" role="math">&#x226F</span><span class="text">≯</span><span class="name">Not Greater-Than</li>
+        <li><span class="unicode" role="math">&#x2270</span><span class="text">≰</span><span class="name">Neither Less-Than Nor Equal To</li>
+        <li><span class="unicode" role="math">&#x2271</span><span class="text">≱</span><span class="name">Neither Greater-Than Nor Equal To</li>
+        <li><span class="unicode" role="math">&#x2272</span><span class="text">≲</span><span class="name">Less-Than or Equivalent To</li>
+        <li><span class="unicode" role="math">&#x2273</span><span class="text">≳</span><span class="name">Greater-Than or Equivalent To</li>
+        <li><span class="unicode" role="math">&#x2274</span><span class="text">≴</span><span class="name">Neither Less-Than Nor Equivalent To</li>
+        <li><span class="unicode" role="math">&#x2275</span><span class="text">≵</span><span class="name">Neither Greater-Than Nor Equivalent To</li>
+        <li><span class="unicode" role="math">&#x2276</span><span class="text">≶</span><span class="name">Less-Than or Greater-Than</li>
+        <li><span class="unicode" role="math">&#x2277</span><span class="text">≷</span><span class="name">Greater-Than or Less-Than</li>
+        <li><span class="unicode" role="math">&#x2278</span><span class="text">≸</span><span class="name">Neither Less-Than Nor Greater-Than</li>
+        <li><span class="unicode" role="math">&#x2279</span><span class="text">≹</span><span class="name">Neither Greater-Than Nor Less-Than</li>
+        <li><span class="unicode" role="math">&#x227A</span><span class="text">≺</span><span class="name">Precedes</li>
+        <li><span class="unicode" role="math">&#x227B</span><span class="text">≻</span><span class="name">Succeeds</li>
+        <li><span class="unicode" role="math">&#x227C</span><span class="text">≼</span><span class="name">Precedes or Equal To</li>
+        <li><span class="unicode" role="math">&#x227D</span><span class="text">≽</span><span class="name">Succeeds or Equal To</li>
+        <li><span class="unicode" role="math">&#x227E</span><span class="text">≾</span><span class="name">Precedes or Equivalent To</li>
+        <li><span class="unicode" role="math">&#x227F</span><span class="text">≿</span><span class="name">Succeeds or Equivalent To</li>
+        <li><span class="unicode" role="math">&#x2280</span><span class="text">⊀</span><span class="name">Does Not Precede</li>
+        <li><span class="unicode" role="math">&#x2281</span><span class="text">⊁</span><span class="name">Does Not Succeed</li>
+        <li><span class="unicode" role="math">&#x2282</span><span class="text">⊂</span><span class="name">Subset Of</li>
+        <li><span class="unicode" role="math">&#x2283</span><span class="text">⊃</span><span class="name">Superset Of</li>
+        <li><span class="unicode" role="math">&#x2284</span><span class="text">⊄</span><span class="name">Not A Subset Of</li>
+        <li><span class="unicode" role="math">&#x2285</span><span class="text">⊅</span><span class="name">Not A Superset Of</li>
+        <li><span class="unicode" role="math">&#x2286</span><span class="text">⊆</span><span class="name">Subset of or Equal To</li>
+        <li><span class="unicode" role="math">&#x2287</span><span class="text">⊇</span><span class="name">Superset of or Equal To</li>
+        <li><span class="unicode" role="math">&#x2288</span><span class="text">⊈</span><span class="name">Neither A Subset of Nor Equal To</li>
+        <li><span class="unicode" role="math">&#x2289</span><span class="text">⊉</span><span class="name">Neither A Superset of Nor Equal To</li>
+        <li><span class="unicode" role="math">&#x228A</span><span class="text">⊊</span><span class="name">Subset of with Not Equal To</li>
+        <li><span class="unicode" role="math">&#x228B</span><span class="text">⊋</span><span class="name">Superset of with Not Equal To</li>
+        <li><span class="unicode" role="math">&#x228C</span><span class="text">⊌</span><span class="name">Multiset</li>
+        <li><span class="unicode" role="math">&#x228D</span><span class="text">⊍</span><span class="name">Multiset Multiplication</li>
+        <li><span class="unicode" role="math">&#x228E</span><span class="text">⊎</span><span class="name">Multiset Union</li>
+        <li><span class="unicode" role="math">&#x228F</span><span class="text">⊏</span><span class="name">Square Image Of</li>
+        <li><span class="unicode" role="math">&#x2290</span><span class="text">⊐</span><span class="name">Square Original Of</li>
+        <li><span class="unicode" role="math">&#x2291</span><span class="text">⊑</span><span class="name">Square Image of or Equal To</li>
+        <li><span class="unicode" role="math">&#x2292</span><span class="text">⊒</span><span class="name">Square Original of or Equal To</li>
+        <li><span class="unicode" role="math">&#x2293</span><span class="text">⊓</span><span class="name">Square Cap</li>
+        <li><span class="unicode" role="math">&#x2294</span><span class="text">⊔</span><span class="name">Square Cup</li>
+        <li><span class="unicode" role="math">&#x2295</span><span class="text">⊕</span><span class="name">Circled Plus</li>
+        <li><span class="unicode" role="math">&#x2296</span><span class="text">⊖</span><span class="name">Circled Minus</li>
+        <li><span class="unicode" role="math">&#x2297</span><span class="text">⊗</span><span class="name">Circled Times</li>
+        <li><span class="unicode" role="math">&#x2298</span><span class="text">⊘</span><span class="name">Circled Division Slash</li>
+        <li><span class="unicode" role="math">&#x2299</span><span class="text">⊙</span><span class="name">Circled Dot Operator</li>
+        <li><span class="unicode" role="math">&#x229A</span><span class="text">⊚</span><span class="name">Circled Ring Operator</li>
+        <li><span class="unicode" role="math">&#x229B</span><span class="text">⊛</span><span class="name">Circled Asterisk Operator</li>
+        <li><span class="unicode" role="math">&#x229C</span><span class="text">⊜</span><span class="name">Circled Equals</li>
+        <li><span class="unicode" role="math">&#x229D</span><span class="text">⊝</span><span class="name">Circled Dash</li>
+        <li><span class="unicode" role="math">&#x229E</span><span class="text">⊞</span><span class="name">Squared Plus</li>
+        <li><span class="unicode" role="math">&#x229F</span><span class="text">⊟</span><span class="name">Squared Minus</li>
+        <li><span class="unicode" role="math">&#x22A0</span><span class="text">⊠</span><span class="name">Squared Times</li>
+        <li><span class="unicode" role="math">&#x22A1</span><span class="text">⊡</span><span class="name">Squared Dot Operator</li>
+        <li><span class="unicode" role="math">&#x22A2</span><span class="text">⊢</span><span class="name">Right Tack</li>
+        <li><span class="unicode" role="math">&#x22A3</span><span class="text">⊣</span><span class="name">Left Tack</li>
+        <li><span class="unicode" role="math">&#x22A4</span><span class="text">⊤</span><span class="name">Down Tack</li>
+        <li><span class="unicode" role="math">&#x22A5</span><span class="text">⊥</span><span class="name">Up Tack</li>
+        <li><span class="unicode" role="math">&#x22A6</span><span class="text">⊦</span><span class="name">Assertion</li>
+        <li><span class="unicode" role="math">&#x22A7</span><span class="text">⊧</span><span class="name">Models</li>
+        <li><span class="unicode" role="math">&#x22A8</span><span class="text">⊨</span><span class="name">True</li>
+        <li><span class="unicode" role="math">&#x22A9</span><span class="text">⊩</span><span class="name">Forces</li>
+        <li><span class="unicode" role="math">&#x22AA</span><span class="text">⊪</span><span class="name">Triple Vertical Bar Right Turnstile</li>
+        <li><span class="unicode" role="math">&#x22AB</span><span class="text">⊫</span><span class="name">Double Vertical Bar Double Right Turnstile</li>
+        <li><span class="unicode" role="math">&#x22AC</span><span class="text">⊬</span><span class="name">Does Not Prove</li>
+        <li><span class="unicode" role="math">&#x22AD</span><span class="text">⊭</span><span class="name">Not True</li>
+        <li><span class="unicode" role="math">&#x22AE</span><span class="text">⊮</span><span class="name">Does Not Force</li>
+        <li><span class="unicode" role="math">&#x22AF</span><span class="text">⊯</span><span class="name">Negated Double Vertical Bar Double Right Turnstile</li>
+        <li><span class="unicode" role="math">&#x22B0</span><span class="text">⊰</span><span class="name">Precedes Under Relation</li>
+        <li><span class="unicode" role="math">&#x22B1</span><span class="text">⊱</span><span class="name">Succeeds Under Relation</li>
+        <li><span class="unicode" role="math">&#x22B2</span><span class="text">⊲</span><span class="name">Normal Subgroup Of</li>
+        <li><span class="unicode" role="math">&#x22B3</span><span class="text">⊳</span><span class="name">Contains as Normal Subgroup</li>
+        <li><span class="unicode" role="math">&#x22B4</span><span class="text">⊴</span><span class="name">Normal Subgroup of or Equal To</li>
+        <li><span class="unicode" role="math">&#x22B5</span><span class="text">⊵</span><span class="name">Contains as Normal Subgroup or Equal To</li>
+        <li><span class="unicode" role="math">&#x22B6</span><span class="text">⊶</span><span class="name">Original Of</li>
+        <li><span class="unicode" role="math">&#x22B7</span><span class="text">⊷</span><span class="name">Image Of</li>
+        <li><span class="unicode" role="math">&#x22B8</span><span class="text">⊸</span><span class="name">Multimap</li>
+        <li><span class="unicode" role="math">&#x22B9</span><span class="text">⊹</span><span class="name">Hermitian Conjugate Matrix</li>
+        <li><span class="unicode" role="math">&#x22BA</span><span class="text">⊺</span><span class="name">Intercalate</li>
+        <li><span class="unicode" role="math">&#x22BB</span><span class="text">⊻</span><span class="name">Xor</li>
+        <li><span class="unicode" role="math">&#x22BC</span><span class="text">⊼</span><span class="name">Nand</li>
+        <li><span class="unicode" role="math">&#x22BD</span><span class="text">⊽</span><span class="name">Nor</li>
+        <li><span class="unicode" role="math">&#x22BE</span><span class="text">⊾</span><span class="name">Right Angle with Arc</li>
+        <li><span class="unicode" role="math">&#x22BF</span><span class="text">⊿</span><span class="name">Right Triangle</li>
+        <li><span class="unicode" role="math">&#x22C0</span><span class="text">⋀</span><span class="name">N-Ary Logical And</li>
+        <li><span class="unicode" role="math">&#x22C1</span><span class="text">⋁</span><span class="name">N-Ary Logical Or</li>
+        <li><span class="unicode" role="math">&#x22C2</span><span class="text">⋂</span><span class="name">N-Ary Intersection</li>
+        <li><span class="unicode" role="math">&#x22C3</span><span class="text">⋃</span><span class="name">N-Ary Union</li>
+        <li><span class="unicode" role="math">&#x22C4</span><span class="text">⋄</span><span class="name">Diamond Operator</li>
+        <li><span class="unicode" role="math">&#x22C5</span><span class="text">⋅</span><span class="name">Dot Operator</li>
+        <li><span class="unicode" role="math">&#x22C6</span><span class="text">⋆</span><span class="name">Star Operator</li>
+        <li><span class="unicode" role="math">&#x22C7</span><span class="text">⋇</span><span class="name">Division Times</li>
+        <li><span class="unicode" role="math">&#x22C8</span><span class="text">⋈</span><span class="name">Bowtie</li>
+        <li><span class="unicode" role="math">&#x22C9</span><span class="text">⋉</span><span class="name">Left Normal Factor Semidirect Product</li>
+        <li><span class="unicode" role="math">&#x22CA</span><span class="text">⋊</span><span class="name">Right Normal Factor Semidirect Product</li>
+        <li><span class="unicode" role="math">&#x22CB</span><span class="text">⋋</span><span class="name">Left Semidirect Product</li>
+        <li><span class="unicode" role="math">&#x22CC</span><span class="text">⋌</span><span class="name">Right Semidirect Product</li>
+        <li><span class="unicode" role="math">&#x22CD</span><span class="text">⋍</span><span class="name">Reversed Tilde Equals</li>
+        <li><span class="unicode" role="math">&#x22CE</span><span class="text">⋎</span><span class="name">Curly Logical Or</li>
+        <li><span class="unicode" role="math">&#x22CF</span><span class="text">⋏</span><span class="name">Curly Logical And</li>
+        <li><span class="unicode" role="math">&#x22D0</span><span class="text">⋐</span><span class="name">Double Subset</li>
+        <li><span class="unicode" role="math">&#x22D1</span><span class="text">⋑</span><span class="name">Double Superset</li>
+        <li><span class="unicode" role="math">&#x22D2</span><span class="text">⋒</span><span class="name">Double Intersection</li>
+        <li><span class="unicode" role="math">&#x22D3</span><span class="text">⋓</span><span class="name">Double Union</li>
+        <li><span class="unicode" role="math">&#x22D4</span><span class="text">⋔</span><span class="name">Pitchfork</li>
+        <li><span class="unicode" role="math">&#x22D5</span><span class="text">⋕</span><span class="name">Equal and Parallel To</li>
+        <li><span class="unicode" role="math">&#x22D6</span><span class="text">⋖</span><span class="name">Less-Than with Dot</li>
+        <li><span class="unicode" role="math">&#x22D7</span><span class="text">⋗</span><span class="name">Greater-Than with Dot</li>
+        <li><span class="unicode" role="math">&#x22D8</span><span class="text">⋘</span><span class="name">Very Much Less-Than</li>
+        <li><span class="unicode" role="math">&#x22D9</span><span class="text">⋙</span><span class="name">Very Much Greater-Than</li>
+        <li><span class="unicode" role="math">&#x22DA</span><span class="text">⋚</span><span class="name">Less-Than Equal to or Greater-Than</li>
+        <li><span class="unicode" role="math">&#x22DB</span><span class="text">⋛</span><span class="name">Greater-Than Equal to or Less-Than</li>
+        <li><span class="unicode" role="math">&#x22DC</span><span class="text">⋜</span><span class="name">Equal to or Less-Than</li>
+        <li><span class="unicode" role="math">&#x22DD</span><span class="text">⋝</span><span class="name">Equal to or Greater-Than</li>
+        <li><span class="unicode" role="math">&#x22DE</span><span class="text">⋞</span><span class="name">Equal to or Precedes</li>
+        <li><span class="unicode" role="math">&#x22DF</span><span class="text">⋟</span><span class="name">Equal to or Succeeds</li>
+        <li><span class="unicode" role="math">&#x22E0</span><span class="text">⋠</span><span class="name">Does Not Precede or Equal</li>
+        <li><span class="unicode" role="math">&#x22E1</span><span class="text">⋡</span><span class="name">Does Not Succeed or Equal</li>
+        <li><span class="unicode" role="math">&#x22E2</span><span class="text">⋢</span><span class="name">Not Square Image of or Equal To</li>
+        <li><span class="unicode" role="math">&#x22E3</span><span class="text">⋣</span><span class="name">Not Square Original of or Equal To</li>
+        <li><span class="unicode" role="math">&#x22E4</span><span class="text">⋤</span><span class="name">Square Image of or Not Equal To</li>
+        <li><span class="unicode" role="math">&#x22E5</span><span class="text">⋥</span><span class="name">Square Original of or Not Equal To</li>
+        <li><span class="unicode" role="math">&#x22E6</span><span class="text">⋦</span><span class="name">Less-Than But Not Equivalent To</li>
+        <li><span class="unicode" role="math">&#x22E7</span><span class="text">⋧</span><span class="name">Greater-Than But Not Equivalent To</li>
+        <li><span class="unicode" role="math">&#x22E8</span><span class="text">⋨</span><span class="name">Precedes But Not Equivalent To</li>
+        <li><span class="unicode" role="math">&#x22E9</span><span class="text">⋩</span><span class="name">Succeeds But Not Equivalent To</li>
+        <li><span class="unicode" role="math">&#x22EA</span><span class="text">⋪</span><span class="name">Not Normal Subgroup Of</li>
+        <li><span class="unicode" role="math">&#x22EB</span><span class="text">⋫</span><span class="name">Does Not Contain as Normal Subgroup</li>
+        <li><span class="unicode" role="math">&#x22EC</span><span class="text">⋬</span><span class="name">Not Normal Subgroup of or Equal To</li>
+        <li><span class="unicode" role="math">&#x22ED</span><span class="text">⋭</span><span class="name">Does Not Contain as Normal Subgroup or Equal</li>
+        <li><span class="unicode" role="math">&#x22EE</span><span class="text">⋮</span><span class="name">Vertical Ellipsis</li>
+        <li><span class="unicode" role="math">&#x22EF</span><span class="text">⋯</span><span class="name">Midline Horizontal Ellipsis</li>
+        <li><span class="unicode" role="math">&#x22F0</span><span class="text">⋰</span><span class="name">Up Right Diagonal Ellipsis</li>
+        <li><span class="unicode" role="math">&#x22F1</span><span class="text">⋱</span><span class="name">Down Right Diagonal Ellipsis</li>
+        <li><span class="unicode" role="math">&#x22F2</span><span class="text">⋲</span><span class="name">Element of with Long Horizontal Stroke</li>
+        <li><span class="unicode" role="math">&#x22F3</span><span class="text">⋳</span><span class="name">Element of with Vertical Bar at End of Horizontal Stroke</li>
+        <li><span class="unicode" role="math">&#x22F4</span><span class="text">⋴</span><span class="name">Small Element of with Vertical Bar at End of Horizontal Stroke</li>
+        <li><span class="unicode" role="math">&#x22F5</span><span class="text">⋵</span><span class="name">Element of with Dot Above</li>
+        <li><span class="unicode" role="math">&#x22F6</span><span class="text">⋶</span><span class="name">Element of with Overbar</li>
+        <li><span class="unicode" role="math">&#x22F7</span><span class="text">⋷</span><span class="name">Small Element of with Overbar</li>
+        <li><span class="unicode" role="math">&#x22F8</span><span class="text">⋸</span><span class="name">Element of with Underbar</li>
+        <li><span class="unicode" role="math">&#x22F9</span><span class="text">⋹</span><span class="name">Element of with Two Horizontal Strokes</li>
+        <li><span class="unicode" role="math">&#x22FA</span><span class="text">⋺</span><span class="name">Contains with Long Horizontal Stroke</li>
+        <li><span class="unicode" role="math">&#x22FB</span><span class="text">⋻</span><span class="name">Contains with Vertical Bar at End of Horizontal Stroke</li>
+        <li><span class="unicode" role="math">&#x22FC</span><span class="text">⋼</span><span class="name">Small Contains with Vertical Bar at End of Horizontal Stroke</li>
+        <li><span class="unicode" role="math">&#x22FD</span><span class="text">⋽</span><span class="name">Contains with Overbar</li>
+        <li><span class="unicode" role="math">&#x22FE</span><span class="text">⋾</span><span class="name">Small Contains with Overbar</li>
+        <li><span class="unicode" role="math">&#x22FF</span><span class="text">⋿</span><span class="name">Z Notation Bag Membership</li>
+        <li><span class="unicode" role="math">&#x2320</span><span class="text">⌠</span><span class="name">Top Half Integral</li>
+        <li><span class="unicode" role="math">&#x2321</span><span class="text">⌡</span><span class="name">Bottom Half Integral</li>
+        <li><span class="unicode" role="math">&#x237C</span><span class="text">⍼</span><span class="name">Right Angle with Downwards Zigzag Arrow</li>
+        <li><span class="unicode" role="math">&#x239B</span><span class="text">⎛</span><span class="name">Left Parenthesis Upper Hook</li>
+        <li><span class="unicode" role="math">&#x239C</span><span class="text">⎜</span><span class="name">Left Parenthesis Extension</li>
+        <li><span class="unicode" role="math">&#x239D</span><span class="text">⎝</span><span class="name">Left Parenthesis Lower Hook</li>
+        <li><span class="unicode" role="math">&#x239E</span><span class="text">⎞</span><span class="name">Right Parenthesis Upper Hook</li>
+        <li><span class="unicode" role="math">&#x239F</span><span class="text">⎟</span><span class="name">Right Parenthesis Extension</li>
+        <li><span class="unicode" role="math">&#x23A0</span><span class="text">⎠</span><span class="name">Right Parenthesis Lower Hook</li>
+        <li><span class="unicode" role="math">&#x23A1</span><span class="text">⎡</span><span class="name">Left Square Bracket Upper Corner</li>
+        <li><span class="unicode" role="math">&#x23A2</span><span class="text">⎢</span><span class="name">Left Square Bracket Extension</li>
+        <li><span class="unicode" role="math">&#x23A3</span><span class="text">⎣</span><span class="name">Left Square Bracket Lower Corner</li>
+        <li><span class="unicode" role="math">&#x23A4</span><span class="text">⎤</span><span class="name">Right Square Bracket Upper Corner</li>
+        <li><span class="unicode" role="math">&#x23A5</span><span class="text">⎥</span><span class="name">Right Square Bracket Extension</li>
+        <li><span class="unicode" role="math">&#x23A6</span><span class="text">⎦</span><span class="name">Right Square Bracket Lower Corner</li>
+        <li><span class="unicode" role="math">&#x23A7</span><span class="text">⎧</span><span class="name">Left Curly Bracket Upper Hook</li>
+        <li><span class="unicode" role="math">&#x23A8</span><span class="text">⎨</span><span class="name">Left Curly Bracket Middle Piece</li>
+        <li><span class="unicode" role="math">&#x23A9</span><span class="text">⎩</span><span class="name">Left Curly Bracket Lower Hook</li>
+        <li><span class="unicode" role="math">&#x23AA</span><span class="text">⎪</span><span class="name">Curly Bracket Extension</li>
+        <li><span class="unicode" role="math">&#x23AB</span><span class="text">⎫</span><span class="name">Right Curly Bracket Upper Hook</li>
+        <li><span class="unicode" role="math">&#x23AC</span><span class="text">⎬</span><span class="name">Right Curly Bracket Middle Piece</li>
+        <li><span class="unicode" role="math">&#x23AD</span><span class="text">⎭</span><span class="name">Right Curly Bracket Lower Hook</li>
+        <li><span class="unicode" role="math">&#x23AE</span><span class="text">⎮</span><span class="name">Integral Extension</li>
+        <li><span class="unicode" role="math">&#x23AF</span><span class="text">⎯</span><span class="name">Horizontal Line Extension</li>
+        <li><span class="unicode" role="math">&#x23B0</span><span class="text">⎰</span><span class="name">Upper Left or Lower Right Curly Bracket Section</li>
+        <li><span class="unicode" role="math">&#x23B1</span><span class="text">⎱</span><span class="name">Upper Right or Lower Left Curly Bracket Section</li>
+        <li><span class="unicode" role="math">&#x23B2</span><span class="text">⎲</span><span class="name">Summation Top</li>
+        <li><span class="unicode" role="math">&#x23B3</span><span class="text">⎳</span><span class="name">Summation Bottom</li>
+        <li><span class="unicode" role="math">&#x23DC</span><span class="text">⏜</span><span class="name">Top Parenthesis</li>
+        <li><span class="unicode" role="math">&#x23DD</span><span class="text">⏝</span><span class="name">Bottom Parenthesis</li>
+        <li><span class="unicode" role="math">&#x23DE</span><span class="text">⏞</span><span class="name">Top Curly Bracket</li>
+        <li><span class="unicode" role="math">&#x23DF</span><span class="text">⏟</span><span class="name">Bottom Curly Bracket</li>
+        <li><span class="unicode" role="math">&#x23E0</span><span class="text">⏠</span><span class="name">Top Tortoise Shell Bracket</li>
+        <li><span class="unicode" role="math">&#x23E1</span><span class="text">⏡</span><span class="name">Bottom Tortoise Shell Bracket</li>
+        <li><span class="unicode" role="math">&#x25B7</span><span class="text">▷</span><span class="name">White Right-Pointing Triangle</li>
+        <li><span class="unicode" role="math">&#x25C1</span><span class="text">◁</span><span class="name">White Left-Pointing Triangle</li>
+        <li><span class="unicode" role="math">&#x25F8</span><span class="text">◸</span><span class="name">Upper Left Triangle</li>
+        <li><span class="unicode" role="math">&#x25F9</span><span class="text">◹</span><span class="name">Upper Right Triangle</li>
+        <li><span class="unicode" role="math">&#x25FA</span><span class="text">◺</span><span class="name">Lower Left Triangle</li>
+        <li><span class="unicode" role="math">&#x25FB</span><span class="text">◻</span><span class="name">White Medium Square</li>
+        <li><span class="unicode" role="math">&#x25FC</span><span class="text">◼</span><span class="name">Black Medium Square</li>
+        <li><span class="unicode" role="math">&#x25FD</span><span class="text">◽</span><span class="name">White Medium Small Square</li>
+        <li><span class="unicode" role="math">&#x25FE</span><span class="text">◾</span><span class="name">Black Medium Small Square</li>
+        <li><span class="unicode" role="math">&#x25FF</span><span class="text">◿</span><span class="name">Lower Right Triangle</li>
+        <li><span class="unicode" role="math">&#x266F</span><span class="text">♯</span><span class="name">Music Sharp Sign</li>
+        <li><span class="unicode" role="math">&#x27C0</span><span class="text">⟀</span><span class="name">Three Dimensional Angle</li>
+        <li><span class="unicode" role="math">&#x27C1</span><span class="text">⟁</span><span class="name">White Triangle Containing Small White Triangle</li>
+        <li><span class="unicode" role="math">&#x27C2</span><span class="text">⟂</span><span class="name">Perpendicular</li>
+        <li><span class="unicode" role="math">&#x27C3</span><span class="text">⟃</span><span class="name">Open Subset</li>
+        <li><span class="unicode" role="math">&#x27C4</span><span class="text">⟄</span><span class="name">Open Superset</li>
+        <li><span class="unicode" role="math">&#x27C7</span><span class="text">⟇</span><span class="name">or with Dot Inside</li>
+        <li><span class="unicode" role="math">&#x27C8</span><span class="text">⟈</span><span class="name">Reverse Solidus Preceding Subset</li>
+        <li><span class="unicode" role="math">&#x27C9</span><span class="text">⟉</span><span class="name">Superset Preceding Solidus</li>
+        <li><span class="unicode" role="math">&#x27CA</span><span class="text">⟊</span><span class="name">Vertical Bar with Horizontal Stroke</li>
+        <li><span class="unicode" role="math">&#x27CB</span><span class="text">⟋</span><span class="name">Mathematical Rising Diagonal</li>
+        <li><span class="unicode" role="math">&#x27CC</span><span class="text">⟌</span><span class="name">Long Division</li>
+        <li><span class="unicode" role="math">&#x27CD</span><span class="text">⟍</span><span class="name">Mathematical Falling Diagonal</li>
+        <li><span class="unicode" role="math">&#x27CE</span><span class="text">⟎</span><span class="name">Squared Logical And</li>
+        <li><span class="unicode" role="math">&#x27CF</span><span class="text">⟏</span><span class="name">Squared Logical Or</li>
+        <li><span class="unicode" role="math">&#x27D0</span><span class="text">⟐</span><span class="name">White Diamond with Centred Dot</li>
+        <li><span class="unicode" role="math">&#x27D1</span><span class="text">⟑</span><span class="name">and with Dot</li>
+        <li><span class="unicode" role="math">&#x27D2</span><span class="text">⟒</span><span class="name">Element of Opening Upwards</li>
+        <li><span class="unicode" role="math">&#x27D3</span><span class="text">⟓</span><span class="name">Lower Right Corner with Dot</li>
+        <li><span class="unicode" role="math">&#x27D4</span><span class="text">⟔</span><span class="name">Upper Left Corner with Dot</li>
+        <li><span class="unicode" role="math">&#x27D5</span><span class="text">⟕</span><span class="name">Left Outer Join</li>
+        <li><span class="unicode" role="math">&#x27D6</span><span class="text">⟖</span><span class="name">Right Outer Join</li>
+        <li><span class="unicode" role="math">&#x27D7</span><span class="text">⟗</span><span class="name">Full Outer Join</li>
+        <li><span class="unicode" role="math">&#x27D8</span><span class="text">⟘</span><span class="name">Large Up Tack</li>
+        <li><span class="unicode" role="math">&#x27D9</span><span class="text">⟙</span><span class="name">Large Down Tack</li>
+        <li><span class="unicode" role="math">&#x27DA</span><span class="text">⟚</span><span class="name">Left and Right Double Turnstile</li>
+        <li><span class="unicode" role="math">&#x27DB</span><span class="text">⟛</span><span class="name">Left and Right Tack</li>
+        <li><span class="unicode" role="math">&#x27DC</span><span class="text">⟜</span><span class="name">Left Multimap</li>
+        <li><span class="unicode" role="math">&#x27DD</span><span class="text">⟝</span><span class="name">Long Right Tack</li>
+        <li><span class="unicode" role="math">&#x27DE</span><span class="text">⟞</span><span class="name">Long Left Tack</li>
+        <li><span class="unicode" role="math">&#x27DF</span><span class="text">⟟</span><span class="name">Up Tack with Circle Above</li>
+        <li><span class="unicode" role="math">&#x27E0</span><span class="text">⟠</span><span class="name">Lozenge Divided By Horizontal Rule</li>
+        <li><span class="unicode" role="math">&#x27E1</span><span class="text">⟡</span><span class="name">White Concave-Sided Diamond</li>
+        <li><span class="unicode" role="math">&#x27E2</span><span class="text">⟢</span><span class="name">White Concave-Sided Diamond with Leftwards Tick</li>
+        <li><span class="unicode" role="math">&#x27E3</span><span class="text">⟣</span><span class="name">White Concave-Sided Diamond with Rightwards Tick</li>
+        <li><span class="unicode" role="math">&#x27E4</span><span class="text">⟤</span><span class="name">White Square with Leftwards Tick</li>
+        <li><span class="unicode" role="math">&#x27E5</span><span class="text">⟥</span><span class="name">White Square with Rightwards Tick</li>
+        <li><span class="unicode" role="math">&#x27F0</span><span class="text">⟰</span><span class="name">Upwards Quadruple Arrow</li>
+        <li><span class="unicode" role="math">&#x27F1</span><span class="text">⟱</span><span class="name">Downwards Quadruple Arrow</li>
+        <li><span class="unicode" role="math">&#x27F2</span><span class="text">⟲</span><span class="name">Anticlockwise Gapped Circle Arrow</li>
+        <li><span class="unicode" role="math">&#x27F3</span><span class="text">⟳</span><span class="name">Clockwise Gapped Circle Arrow</li>
+        <li><span class="unicode" role="math">&#x27F4</span><span class="text">⟴</span><span class="name">Right Arrow with Circled Plus</li>
+        <li><span class="unicode" role="math">&#x27F5</span><span class="text">⟵</span><span class="name">Long Leftwards Arrow</li>
+        <li><span class="unicode" role="math">&#x27F6</span><span class="text">⟶</span><span class="name">Long Rightwards Arrow</li>
+        <li><span class="unicode" role="math">&#x27F7</span><span class="text">⟷</span><span class="name">Long Left Right Arrow</li>
+        <li><span class="unicode" role="math">&#x27F8</span><span class="text">⟸</span><span class="name">Long Leftwards Double Arrow</li>
+        <li><span class="unicode" role="math">&#x27F9</span><span class="text">⟹</span><span class="name">Long Rightwards Double Arrow</li>
+        <li><span class="unicode" role="math">&#x27FA</span><span class="text">⟺</span><span class="name">Long Left Right Double Arrow</li>
+        <li><span class="unicode" role="math">&#x27FB</span><span class="text">⟻</span><span class="name">Long Leftwards Arrow from Bar</li>
+        <li><span class="unicode" role="math">&#x27FC</span><span class="text">⟼</span><span class="name">Long Rightwards Arrow from Bar</li>
+        <li><span class="unicode" role="math">&#x27FD</span><span class="text">⟽</span><span class="name">Long Leftwards Double Arrow from Bar</li>
+        <li><span class="unicode" role="math">&#x27FE</span><span class="text">⟾</span><span class="name">Long Rightwards Double Arrow from Bar</li>
+        <li><span class="unicode" role="math">&#x27FF</span><span class="text">⟿</span><span class="name">Long Rightwards Squiggle Arrow</li>
+        <li><span class="unicode" role="math">&#x2900</span><span class="text">⤀</span><span class="name">Rightwards Two-Headed Arrow with Vertical Stroke</li>
+        <li><span class="unicode" role="math">&#x2901</span><span class="text">⤁</span><span class="name">Rightwards Two-Headed Arrow with Double Vertical Stroke</li>
+        <li><span class="unicode" role="math">&#x2902</span><span class="text">⤂</span><span class="name">Leftwards Double Arrow with Vertical Stroke</li>
+        <li><span class="unicode" role="math">&#x2903</span><span class="text">⤃</span><span class="name">Rightwards Double Arrow with Vertical Stroke</li>
+        <li><span class="unicode" role="math">&#x2904</span><span class="text">⤄</span><span class="name">Left Right Double Arrow with Vertical Stroke</li>
+        <li><span class="unicode" role="math">&#x2905</span><span class="text">⤅</span><span class="name">Rightwards Two-Headed Arrow from Bar</li>
+        <li><span class="unicode" role="math">&#x2906</span><span class="text">⤆</span><span class="name">Leftwards Double Arrow from Bar</li>
+        <li><span class="unicode" role="math">&#x2907</span><span class="text">⤇</span><span class="name">Rightwards Double Arrow from Bar</li>
+        <li><span class="unicode" role="math">&#x2908</span><span class="text">⤈</span><span class="name">Downwards Arrow with Horizontal Stroke</li>
+        <li><span class="unicode" role="math">&#x2909</span><span class="text">⤉</span><span class="name">Upwards Arrow with Horizontal Stroke</li>
+        <li><span class="unicode" role="math">&#x290A</span><span class="text">⤊</span><span class="name">Upwards Triple Arrow</li>
+        <li><span class="unicode" role="math">&#x290B</span><span class="text">⤋</span><span class="name">Downwards Triple Arrow</li>
+        <li><span class="unicode" role="math">&#x290C</span><span class="text">⤌</span><span class="name">Leftwards Double Dash Arrow</li>
+        <li><span class="unicode" role="math">&#x290D</span><span class="text">⤍</span><span class="name">Rightwards Double Dash Arrow</li>
+        <li><span class="unicode" role="math">&#x290E</span><span class="text">⤎</span><span class="name">Leftwards Triple Dash Arrow</li>
+        <li><span class="unicode" role="math">&#x290F</span><span class="text">⤏</span><span class="name">Rightwards Triple Dash Arrow</li>
+        <li><span class="unicode" role="math">&#x2910</span><span class="text">⤐</span><span class="name">Rightwards Two-Headed Triple Dash Arrow</li>
+        <li><span class="unicode" role="math">&#x2911</span><span class="text">⤑</span><span class="name">Rightwards Arrow with Dotted Stem</li>
+        <li><span class="unicode" role="math">&#x2912</span><span class="text">⤒</span><span class="name">Upwards Arrow to Bar</li>
+        <li><span class="unicode" role="math">&#x2913</span><span class="text">⤓</span><span class="name">Downwards Arrow to Bar</li>
+        <li><span class="unicode" role="math">&#x2914</span><span class="text">⤔</span><span class="name">Rightwards Arrow with Tail with Vertical Stroke</li>
+        <li><span class="unicode" role="math">&#x2915</span><span class="text">⤕</span><span class="name">Rightwards Arrow with Tail with Double Vertical Stroke</li>
+        <li><span class="unicode" role="math">&#x2916</span><span class="text">⤖</span><span class="name">Rightwards Two-Headed Arrow with Tail</li>
+        <li><span class="unicode" role="math">&#x2917</span><span class="text">⤗</span><span class="name">Rightwards Two-Headed Arrow with Tail with Vertical Stroke</li>
+        <li><span class="unicode" role="math">&#x2918</span><span class="text">⤘</span><span class="name">Rightwards Two-Headed Arrow with Tail with Double Vertical Stroke</li>
+        <li><span class="unicode" role="math">&#x2919</span><span class="text">⤙</span><span class="name">Leftwards Arrow-Tail</li>
+        <li><span class="unicode" role="math">&#x291A</span><span class="text">⤚</span><span class="name">Rightwards Arrow-Tail</li>
+        <li><span class="unicode" role="math">&#x291B</span><span class="text">⤛</span><span class="name">Leftwards Double Arrow-Tail</li>
+        <li><span class="unicode" role="math">&#x291C</span><span class="text">⤜</span><span class="name">Rightwards Double Arrow-Tail</li>
+        <li><span class="unicode" role="math">&#x291D</span><span class="text">⤝</span><span class="name">Leftwards Arrow to Black Diamond</li>
+        <li><span class="unicode" role="math">&#x291E</span><span class="text">⤞</span><span class="name">Rightwards Arrow to Black Diamond</li>
+        <li><span class="unicode" role="math">&#x291F</span><span class="text">⤟</span><span class="name">Leftwards Arrow from Bar to Black Diamond</li>
+        <li><span class="unicode" role="math">&#x2920</span><span class="text">⤠</span><span class="name">Rightwards Arrow from Bar to Black Diamond</li>
+        <li><span class="unicode" role="math">&#x2921</span><span class="text">⤡</span><span class="name">North West and South East Arrow</li>
+        <li><span class="unicode" role="math">&#x2922</span><span class="text">⤢</span><span class="name">North East and South West Arrow</li>
+        <li><span class="unicode" role="math">&#x2923</span><span class="text">⤣</span><span class="name">North West Arrow with Hook</li>
+        <li><span class="unicode" role="math">&#x2924</span><span class="text">⤤</span><span class="name">North East Arrow with Hook</li>
+        <li><span class="unicode" role="math">&#x2925</span><span class="text">⤥</span><span class="name">South East Arrow with Hook</li>
+        <li><span class="unicode" role="math">&#x2926</span><span class="text">⤦</span><span class="name">South West Arrow with Hook</li>
+        <li><span class="unicode" role="math">&#x2927</span><span class="text">⤧</span><span class="name">North West Arrow and North East Arrow</li>
+        <li><span class="unicode" role="math">&#x2928</span><span class="text">⤨</span><span class="name">North East Arrow and South East Arrow</li>
+        <li><span class="unicode" role="math">&#x2929</span><span class="text">⤩</span><span class="name">South East Arrow and South West Arrow</li>
+        <li><span class="unicode" role="math">&#x292A</span><span class="text">⤪</span><span class="name">South West Arrow and North West Arrow</li>
+        <li><span class="unicode" role="math">&#x292B</span><span class="text">⤫</span><span class="name">Rising Diagonal Crossing Falling Diagonal</li>
+        <li><span class="unicode" role="math">&#x292C</span><span class="text">⤬</span><span class="name">Falling Diagonal Crossing Rising Diagonal</li>
+        <li><span class="unicode" role="math">&#x292D</span><span class="text">⤭</span><span class="name">South East Arrow Crossing North East Arrow</li>
+        <li><span class="unicode" role="math">&#x292E</span><span class="text">⤮</span><span class="name">North East Arrow Crossing South East Arrow</li>
+        <li><span class="unicode" role="math">&#x292F</span><span class="text">⤯</span><span class="name">Falling Diagonal Crossing North East Arrow</li>
+        <li><span class="unicode" role="math">&#x2930</span><span class="text">⤰</span><span class="name">Rising Diagonal Crossing South East Arrow</li>
+        <li><span class="unicode" role="math">&#x2931</span><span class="text">⤱</span><span class="name">North East Arrow Crossing North West Arrow</li>
+        <li><span class="unicode" role="math">&#x2932</span><span class="text">⤲</span><span class="name">North West Arrow Crossing North East Arrow</li>
+        <li><span class="unicode" role="math">&#x2933</span><span class="text">⤳</span><span class="name">Wave Arrow Pointing Directly Right</li>
+        <li><span class="unicode" role="math">&#x2934</span><span class="text">⤴</span><span class="name">Arrow Pointing Rightwards Then Curving Upwards</li>
+        <li><span class="unicode" role="math">&#x2935</span><span class="text">⤵</span><span class="name">Arrow Pointing Rightwards Then Curving Downwards</li>
+        <li><span class="unicode" role="math">&#x2936</span><span class="text">⤶</span><span class="name">Arrow Pointing Downwards Then Curving Leftwards</li>
+        <li><span class="unicode" role="math">&#x2937</span><span class="text">⤷</span><span class="name">Arrow Pointing Downwards Then Curving Rightwards</li>
+        <li><span class="unicode" role="math">&#x2938</span><span class="text">⤸</span><span class="name">Right-Side Arc Clockwise Arrow</li>
+        <li><span class="unicode" role="math">&#x2939</span><span class="text">⤹</span><span class="name">Left-Side Arc Anticlockwise Arrow</li>
+        <li><span class="unicode" role="math">&#x293A</span><span class="text">⤺</span><span class="name">Top Arc Anticlockwise Arrow</li>
+        <li><span class="unicode" role="math">&#x293B</span><span class="text">⤻</span><span class="name">Bottom Arc Anticlockwise Arrow</li>
+        <li><span class="unicode" role="math">&#x293C</span><span class="text">⤼</span><span class="name">Top Arc Clockwise Arrow with Minus</li>
+        <li><span class="unicode" role="math">&#x293D</span><span class="text">⤽</span><span class="name">Top Arc Anticlockwise Arrow with Plus</li>
+        <li><span class="unicode" role="math">&#x293E</span><span class="text">⤾</span><span class="name">Lower Right Semicircular Clockwise Arrow</li>
+        <li><span class="unicode" role="math">&#x293F</span><span class="text">⤿</span><span class="name">Lower Left Semicircular Anticlockwise Arrow</li>
+        <li><span class="unicode" role="math">&#x2940</span><span class="text">⥀</span><span class="name">Anticlockwise Closed Circle Arrow</li>
+        <li><span class="unicode" role="math">&#x2941</span><span class="text">⥁</span><span class="name">Clockwise Closed Circle Arrow</li>
+        <li><span class="unicode" role="math">&#x2942</span><span class="text">⥂</span><span class="name">Rightwards Arrow Above Short Leftwards Arrow</li>
+        <li><span class="unicode" role="math">&#x2943</span><span class="text">⥃</span><span class="name">Leftwards Arrow Above Short Rightwards Arrow</li>
+        <li><span class="unicode" role="math">&#x2944</span><span class="text">⥄</span><span class="name">Short Rightwards Arrow Above Leftwards Arrow</li>
+        <li><span class="unicode" role="math">&#x2945</span><span class="text">⥅</span><span class="name">Rightwards Arrow with Plus Below</li>
+        <li><span class="unicode" role="math">&#x2946</span><span class="text">⥆</span><span class="name">Leftwards Arrow with Plus Below</li>
+        <li><span class="unicode" role="math">&#x2947</span><span class="text">⥇</span><span class="name">Rightwards Arrow Through X</li>
+        <li><span class="unicode" role="math">&#x2948</span><span class="text">⥈</span><span class="name">Left Right Arrow Through Small Circle</li>
+        <li><span class="unicode" role="math">&#x2949</span><span class="text">⥉</span><span class="name">Upwards Two-Headed Arrow from Small Circle</li>
+        <li><span class="unicode" role="math">&#x294A</span><span class="text">⥊</span><span class="name">Left Barb Up Right Barb Down Harpoon</li>
+        <li><span class="unicode" role="math">&#x294B</span><span class="text">⥋</span><span class="name">Left Barb Down Right Barb Up Harpoon</li>
+        <li><span class="unicode" role="math">&#x294C</span><span class="text">⥌</span><span class="name">Up Barb Right Down Barb Left Harpoon</li>
+        <li><span class="unicode" role="math">&#x294D</span><span class="text">⥍</span><span class="name">Up Barb Left Down Barb Right Harpoon</li>
+        <li><span class="unicode" role="math">&#x294E</span><span class="text">⥎</span><span class="name">Left Barb Up Right Barb Up Harpoon</li>
+        <li><span class="unicode" role="math">&#x294F</span><span class="text">⥏</span><span class="name">Up Barb Right Down Barb Right Harpoon</li>
+        <li><span class="unicode" role="math">&#x2950</span><span class="text">⥐</span><span class="name">Left Barb Down Right Barb Down Harpoon</li>
+        <li><span class="unicode" role="math">&#x2951</span><span class="text">⥑</span><span class="name">Up Barb Left Down Barb Left Harpoon</li>
+        <li><span class="unicode" role="math">&#x2952</span><span class="text">⥒</span><span class="name">Leftwards Harpoon with Barb Up to Bar</li>
+        <li><span class="unicode" role="math">&#x2953</span><span class="text">⥓</span><span class="name">Rightwards Harpoon with Barb Up to Bar</li>
+        <li><span class="unicode" role="math">&#x2954</span><span class="text">⥔</span><span class="name">Upwards Harpoon with Barb Right to Bar</li>
+        <li><span class="unicode" role="math">&#x2955</span><span class="text">⥕</span><span class="name">Downwards Harpoon with Barb Right to Bar</li>
+        <li><span class="unicode" role="math">&#x2956</span><span class="text">⥖</span><span class="name">Leftwards Harpoon with Barb Down to Bar</li>
+        <li><span class="unicode" role="math">&#x2957</span><span class="text">⥗</span><span class="name">Rightwards Harpoon with Barb Down to Bar</li>
+        <li><span class="unicode" role="math">&#x2958</span><span class="text">⥘</span><span class="name">Upwards Harpoon with Barb Left to Bar</li>
+        <li><span class="unicode" role="math">&#x2959</span><span class="text">⥙</span><span class="name">Downwards Harpoon with Barb Left to Bar</li>
+        <li><span class="unicode" role="math">&#x295A</span><span class="text">⥚</span><span class="name">Leftwards Harpoon with Barb Up from Bar</li>
+        <li><span class="unicode" role="math">&#x295B</span><span class="text">⥛</span><span class="name">Rightwards Harpoon with Barb Up from Bar</li>
+        <li><span class="unicode" role="math">&#x295C</span><span class="text">⥜</span><span class="name">Upwards Harpoon with Barb Right from Bar</li>
+        <li><span class="unicode" role="math">&#x295D</span><span class="text">⥝</span><span class="name">Downwards Harpoon with Barb Right from Bar</li>
+        <li><span class="unicode" role="math">&#x295E</span><span class="text">⥞</span><span class="name">Leftwards Harpoon with Barb Down from Bar</li>
+        <li><span class="unicode" role="math">&#x295F</span><span class="text">⥟</span><span class="name">Rightwards Harpoon with Barb Down from Bar</li>
+        <li><span class="unicode" role="math">&#x2960</span><span class="text">⥠</span><span class="name">Upwards Harpoon with Barb Left from Bar</li>
+        <li><span class="unicode" role="math">&#x2961</span><span class="text">⥡</span><span class="name">Downwards Harpoon with Barb Left from Bar</li>
+        <li><span class="unicode" role="math">&#x2962</span><span class="text">⥢</span><span class="name">Leftwards Harpoon with Barb Up Above Leftwards Harpoon with Barb Down</li>
+        <li><span class="unicode" role="math">&#x2963</span><span class="text">⥣</span><span class="name">Upwards Harpoon with Barb Left Beside Upwards Harpoon with Barb Right</li>
+        <li><span class="unicode" role="math">&#x2964</span><span class="text">⥤</span><span class="name">Rightwards Harpoon with Barb Up Above Rightwards Harpoon with Barb Down</li>
+        <li><span class="unicode" role="math">&#x2965</span><span class="text">⥥</span><span class="name">Downwards Harpoon with Barb Left Beside Downwards Harpoon with Barb Right</li>
+        <li><span class="unicode" role="math">&#x2966</span><span class="text">⥦</span><span class="name">Leftwards Harpoon with Barb Up Above Rightwards Harpoon with Barb Up</li>
+        <li><span class="unicode" role="math">&#x2967</span><span class="text">⥧</span><span class="name">Leftwards Harpoon with Barb Down Above Rightwards Harpoon with Barb Down</li>
+        <li><span class="unicode" role="math">&#x2968</span><span class="text">⥨</span><span class="name">Rightwards Harpoon with Barb Up Above Leftwards Harpoon with Barb Up</li>
+        <li><span class="unicode" role="math">&#x2969</span><span class="text">⥩</span><span class="name">Rightwards Harpoon with Barb Down Above Leftwards Harpoon with Barb Down</li>
+        <li><span class="unicode" role="math">&#x296A</span><span class="text">⥪</span><span class="name">Leftwards Harpoon with Barb Up Above Long Dash</li>
+        <li><span class="unicode" role="math">&#x296B</span><span class="text">⥫</span><span class="name">Leftwards Harpoon with Barb Down Below Long Dash</li>
+        <li><span class="unicode" role="math">&#x296C</span><span class="text">⥬</span><span class="name">Rightwards Harpoon with Barb Up Above Long Dash</li>
+        <li><span class="unicode" role="math">&#x296D</span><span class="text">⥭</span><span class="name">Rightwards Harpoon with Barb Down Below Long Dash</li>
+        <li><span class="unicode" role="math">&#x296E</span><span class="text">⥮</span><span class="name">Upwards Harpoon with Barb Left Beside Downwards Harpoon with Barb Right</li>
+        <li><span class="unicode" role="math">&#x296F</span><span class="text">⥯</span><span class="name">Downwards Harpoon with Barb Left Beside Upwards Harpoon with Barb Right</li>
+        <li><span class="unicode" role="math">&#x2970</span><span class="text">⥰</span><span class="name">Right Double Arrow with Rounded Head</li>
+        <li><span class="unicode" role="math">&#x2971</span><span class="text">⥱</span><span class="name">Equals Sign Above Rightwards Arrow</li>
+        <li><span class="unicode" role="math">&#x2972</span><span class="text">⥲</span><span class="name">Tilde Operator Above Rightwards Arrow</li>
+        <li><span class="unicode" role="math">&#x2973</span><span class="text">⥳</span><span class="name">Leftwards Arrow Above Tilde Operator</li>
+        <li><span class="unicode" role="math">&#x2974</span><span class="text">⥴</span><span class="name">Rightwards Arrow Above Tilde Operator</li>
+        <li><span class="unicode" role="math">&#x2975</span><span class="text">⥵</span><span class="name">Rightwards Arrow Above Almost Equal To</li>
+        <li><span class="unicode" role="math">&#x2976</span><span class="text">⥶</span><span class="name">Less-Than Above Leftwards Arrow</li>
+        <li><span class="unicode" role="math">&#x2977</span><span class="text">⥷</span><span class="name">Leftwards Arrow Through Less-Than</li>
+        <li><span class="unicode" role="math">&#x2978</span><span class="text">⥸</span><span class="name">Greater-Than Above Rightwards Arrow</li>
+        <li><span class="unicode" role="math">&#x2979</span><span class="text">⥹</span><span class="name">Subset Above Rightwards Arrow</li>
+        <li><span class="unicode" role="math">&#x297A</span><span class="text">⥺</span><span class="name">Leftwards Arrow Through Subset</li>
+        <li><span class="unicode" role="math">&#x297B</span><span class="text">⥻</span><span class="name">Superset Above Leftwards Arrow</li>
+        <li><span class="unicode" role="math">&#x297C</span><span class="text">⥼</span><span class="name">Left Fish Tail</li>
+        <li><span class="unicode" role="math">&#x297D</span><span class="text">⥽</span><span class="name">Right Fish Tail</li>
+        <li><span class="unicode" role="math">&#x297E</span><span class="text">⥾</span><span class="name">Up Fish Tail</li>
+        <li><span class="unicode" role="math">&#x297F</span><span class="text">⥿</span><span class="name">Down Fish Tail</li>
+        <li><span class="unicode" role="math">&#x2980</span><span class="text">⦀</span><span class="name">Triple Vertical Bar Delimiter</li>
+        <li><span class="unicode" role="math">&#x2981</span><span class="text">⦁</span><span class="name">Z Notation Spot</li>
+        <li><span class="unicode" role="math">&#x2982</span><span class="text">⦂</span><span class="name">Z Notation Type Colon</li>
+        <li><span class="unicode" role="math">&#x2999</span><span class="text">⦙</span><span class="name">Dotted Fence</li>
+        <li><span class="unicode" role="math">&#x299A</span><span class="text">⦚</span><span class="name">Vertical Zigzag Line</li>
+        <li><span class="unicode" role="math">&#x299B</span><span class="text">⦛</span><span class="name">Measured Angle Opening Left</li>
+        <li><span class="unicode" role="math">&#x299C</span><span class="text">⦜</span><span class="name">Right Angle Variant with Square</li>
+        <li><span class="unicode" role="math">&#x299D</span><span class="text">⦝</span><span class="name">Measured Right Angle with Dot</li>
+        <li><span class="unicode" role="math">&#x299E</span><span class="text">⦞</span><span class="name">Angle with S Inside</li>
+        <li><span class="unicode" role="math">&#x299F</span><span class="text">⦟</span><span class="name">Acute Angle</li>
+        <li><span class="unicode" role="math">&#x29A0</span><span class="text">⦠</span><span class="name">Spherical Angle Opening Left</li>
+        <li><span class="unicode" role="math">&#x29A1</span><span class="text">⦡</span><span class="name">Spherical Angle Opening Up</li>
+        <li><span class="unicode" role="math">&#x29A2</span><span class="text">⦢</span><span class="name">Turned Angle</li>
+        <li><span class="unicode" role="math">&#x29A3</span><span class="text">⦣</span><span class="name">Reversed Angle</li>
+        <li><span class="unicode" role="math">&#x29A4</span><span class="text">⦤</span><span class="name">Angle with Underbar</li>
+        <li><span class="unicode" role="math">&#x29A5</span><span class="text">⦥</span><span class="name">Reversed Angle with Underbar</li>
+        <li><span class="unicode" role="math">&#x29A6</span><span class="text">⦦</span><span class="name">Oblique Angle Opening Up</li>
+        <li><span class="unicode" role="math">&#x29A7</span><span class="text">⦧</span><span class="name">Oblique Angle Opening Down</li>
+        <li><span class="unicode" role="math">&#x29A8</span><span class="text">⦨</span><span class="name">Measured Angle with Open Arm Ending In Arrow Pointing Up and Right</li>
+        <li><span class="unicode" role="math">&#x29A9</span><span class="text">⦩</span><span class="name">Measured Angle with Open Arm Ending In Arrow Pointing Up and Left</li>
+        <li><span class="unicode" role="math">&#x29AA</span><span class="text">⦪</span><span class="name">Measured Angle with Open Arm Ending In Arrow Pointing Down and Right</li>
+        <li><span class="unicode" role="math">&#x29AB</span><span class="text">⦫</span><span class="name">Measured Angle with Open Arm Ending In Arrow Pointing Down and Left</li>
+        <li><span class="unicode" role="math">&#x29AC</span><span class="text">⦬</span><span class="name">Measured Angle with Open Arm Ending In Arrow Pointing Right and Up</li>
+        <li><span class="unicode" role="math">&#x29AD</span><span class="text">⦭</span><span class="name">Measured Angle with Open Arm Ending In Arrow Pointing Left and Up</li>
+        <li><span class="unicode" role="math">&#x29AE</span><span class="text">⦮</span><span class="name">Measured Angle with Open Arm Ending In Arrow Pointing Right and Down</li>
+        <li><span class="unicode" role="math">&#x29AF</span><span class="text">⦯</span><span class="name">Measured Angle with Open Arm Ending In Arrow Pointing Left and Down</li>
+        <li><span class="unicode" role="math">&#x29B0</span><span class="text">⦰</span><span class="name">Reversed Empty Set</li>
+        <li><span class="unicode" role="math">&#x29B1</span><span class="text">⦱</span><span class="name">Empty Set with Overbar</li>
+        <li><span class="unicode" role="math">&#x29B2</span><span class="text">⦲</span><span class="name">Empty Set with Small Circle Above</li>
+        <li><span class="unicode" role="math">&#x29B3</span><span class="text">⦳</span><span class="name">Empty Set with Right Arrow Above</li>
+        <li><span class="unicode" role="math">&#x29B4</span><span class="text">⦴</span><span class="name">Empty Set with Left Arrow Above</li>
+        <li><span class="unicode" role="math">&#x29B5</span><span class="text">⦵</span><span class="name">Circle with Horizontal Bar</li>
+        <li><span class="unicode" role="math">&#x29B6</span><span class="text">⦶</span><span class="name">Circled Vertical Bar</li>
+        <li><span class="unicode" role="math">&#x29B7</span><span class="text">⦷</span><span class="name">Circled Parallel</li>
+        <li><span class="unicode" role="math">&#x29B8</span><span class="text">⦸</span><span class="name">Circled Reverse Solidus</li>
+        <li><span class="unicode" role="math">&#x29B9</span><span class="text">⦹</span><span class="name">Circled Perpendicular</li>
+        <li><span class="unicode" role="math">&#x29BA</span><span class="text">⦺</span><span class="name">Circle Divided By Horizontal Bar and Top Half Divided By Vertical Bar</li>
+        <li><span class="unicode" role="math">&#x29BB</span><span class="text">⦻</span><span class="name">Circle with Superimposed X</li>
+        <li><span class="unicode" role="math">&#x29BC</span><span class="text">⦼</span><span class="name">Circled Anticlockwise-Rotated Division Sign</li>
+        <li><span class="unicode" role="math">&#x29BD</span><span class="text">⦽</span><span class="name">Up Arrow Through Circle</li>
+        <li><span class="unicode" role="math">&#x29BE</span><span class="text">⦾</span><span class="name">Circled White Bullet</li>
+        <li><span class="unicode" role="math">&#x29BF</span><span class="text">⦿</span><span class="name">Circled Bullet</li>
+        <li><span class="unicode" role="math">&#x29C0</span><span class="text">⧀</span><span class="name">Circled Less-Than</li>
+        <li><span class="unicode" role="math">&#x29C1</span><span class="text">⧁</span><span class="name">Circled Greater-Than</li>
+        <li><span class="unicode" role="math">&#x29C2</span><span class="text">⧂</span><span class="name">Circle with Small Circle to the Right</li>
+        <li><span class="unicode" role="math">&#x29C3</span><span class="text">⧃</span><span class="name">Circle with Two Horizontal Strokes to the Right</li>
+        <li><span class="unicode" role="math">&#x29C4</span><span class="text">⧄</span><span class="name">Squared Rising Diagonal Slash</li>
+        <li><span class="unicode" role="math">&#x29C5</span><span class="text">⧅</span><span class="name">Squared Falling Diagonal Slash</li>
+        <li><span class="unicode" role="math">&#x29C6</span><span class="text">⧆</span><span class="name">Squared Asterisk</li>
+        <li><span class="unicode" role="math">&#x29C7</span><span class="text">⧇</span><span class="name">Squared Small Circle</li>
+        <li><span class="unicode" role="math">&#x29C8</span><span class="text">⧈</span><span class="name">Squared Square</li>
+        <li><span class="unicode" role="math">&#x29C9</span><span class="text">⧉</span><span class="name">Two Joined Squares</li>
+        <li><span class="unicode" role="math">&#x29CA</span><span class="text">⧊</span><span class="name">Triangle with Dot Above</li>
+        <li><span class="unicode" role="math">&#x29CB</span><span class="text">⧋</span><span class="name">Triangle with Underbar</li>
+        <li><span class="unicode" role="math">&#x29CC</span><span class="text">⧌</span><span class="name">S In Triangle</li>
+        <li><span class="unicode" role="math">&#x29CD</span><span class="text">⧍</span><span class="name">Triangle with Serifs at Bottom</li>
+        <li><span class="unicode" role="math">&#x29CE</span><span class="text">⧎</span><span class="name">Right Triangle Above Left Triangle</li>
+        <li><span class="unicode" role="math">&#x29CF</span><span class="text">⧏</span><span class="name">Left Triangle Beside Vertical Bar</li>
+        <li><span class="unicode" role="math">&#x29D0</span><span class="text">⧐</span><span class="name">Vertical Bar Beside Right Triangle</li>
+        <li><span class="unicode" role="math">&#x29D1</span><span class="text">⧑</span><span class="name">Bowtie with Left Half Black</li>
+        <li><span class="unicode" role="math">&#x29D2</span><span class="text">⧒</span><span class="name">Bowtie with Right Half Black</li>
+        <li><span class="unicode" role="math">&#x29D3</span><span class="text">⧓</span><span class="name">Black Bowtie</li>
+        <li><span class="unicode" role="math">&#x29D4</span><span class="text">⧔</span><span class="name">Times with Left Half Black</li>
+        <li><span class="unicode" role="math">&#x29D5</span><span class="text">⧕</span><span class="name">Times with Right Half Black</li>
+        <li><span class="unicode" role="math">&#x29D6</span><span class="text">⧖</span><span class="name">White Hourglass</li>
+        <li><span class="unicode" role="math">&#x29D7</span><span class="text">⧗</span><span class="name">Black Hourglass</li>
+        <li><span class="unicode" role="math">&#x29DC</span><span class="text">⧜</span><span class="name">Incomplete Infinity</li>
+        <li><span class="unicode" role="math">&#x29DD</span><span class="text">⧝</span><span class="name">Tie Over Infinity</li>
+        <li><span class="unicode" role="math">&#x29DE</span><span class="text">⧞</span><span class="name">Infinity Negated with Vertical Bar</li>
+        <li><span class="unicode" role="math">&#x29DF</span><span class="text">⧟</span><span class="name">Double-Ended Multimap</li>
+        <li><span class="unicode" role="math">&#x29E0</span><span class="text">⧠</span><span class="name">Square with Contoured Outline</li>
+        <li><span class="unicode" role="math">&#x29E1</span><span class="text">⧡</span><span class="name">Increases As</li>
+        <li><span class="unicode" role="math">&#x29E2</span><span class="text">⧢</span><span class="name">Shuffle Product</li>
+        <li><span class="unicode" role="math">&#x29E3</span><span class="text">⧣</span><span class="name">Equals Sign and Slanted Parallel</li>
+        <li><span class="unicode" role="math">&#x29E4</span><span class="text">⧤</span><span class="name">Equals Sign and Slanted Parallel with Tilde Above</li>
+        <li><span class="unicode" role="math">&#x29E5</span><span class="text">⧥</span><span class="name">Identical to and Slanted Parallel</li>
+        <li><span class="unicode" role="math">&#x29E6</span><span class="text">⧦</span><span class="name">Gleich Stark</li>
+        <li><span class="unicode" role="math">&#x29E7</span><span class="text">⧧</span><span class="name">Thermodynamic</li>
+        <li><span class="unicode" role="math">&#x29E8</span><span class="text">⧨</span><span class="name">Down-Pointing Triangle with Left Half Black</li>
+        <li><span class="unicode" role="math">&#x29E9</span><span class="text">⧩</span><span class="name">Down-Pointing Triangle with Right Half Black</li>
+        <li><span class="unicode" role="math">&#x29EA</span><span class="text">⧪</span><span class="name">Black Diamond with Down Arrow</li>
+        <li><span class="unicode" role="math">&#x29EB</span><span class="text">⧫</span><span class="name">Black Lozenge</li>
+        <li><span class="unicode" role="math">&#x29EC</span><span class="text">⧬</span><span class="name">White Circle with Down Arrow</li>
+        <li><span class="unicode" role="math">&#x29ED</span><span class="text">⧭</span><span class="name">Black Circle with Down Arrow</li>
+        <li><span class="unicode" role="math">&#x29EE</span><span class="text">⧮</span><span class="name">Error-Barred White Square</li>
+        <li><span class="unicode" role="math">&#x29EF</span><span class="text">⧯</span><span class="name">Error-Barred Black Square</li>
+        <li><span class="unicode" role="math">&#x29F0</span><span class="text">⧰</span><span class="name">Error-Barred White Diamond</li>
+        <li><span class="unicode" role="math">&#x29F1</span><span class="text">⧱</span><span class="name">Error-Barred Black Diamond</li>
+        <li><span class="unicode" role="math">&#x29F2</span><span class="text">⧲</span><span class="name">Error-Barred White Circle</li>
+        <li><span class="unicode" role="math">&#x29F3</span><span class="text">⧳</span><span class="name">Error-Barred Black Circle</li>
+        <li><span class="unicode" role="math">&#x29F4</span><span class="text">⧴</span><span class="name">Rule-Delayed</li>
+        <li><span class="unicode" role="math">&#x29F5</span><span class="text">⧵</span><span class="name">Reverse Solidus Operator</li>
+        <li><span class="unicode" role="math">&#x29F6</span><span class="text">⧶</span><span class="name">Solidus with Overbar</li>
+        <li><span class="unicode" role="math">&#x29F7</span><span class="text">⧷</span><span class="name">Reverse Solidus with Horizontal Stroke</li>
+        <li><span class="unicode" role="math">&#x29F8</span><span class="text">⧸</span><span class="name">Big Solidus</li>
+        <li><span class="unicode" role="math">&#x29F9</span><span class="text">⧹</span><span class="name">Big Reverse Solidus</li>
+        <li><span class="unicode" role="math">&#x29FA</span><span class="text">⧺</span><span class="name">Double Plus</li>
+        <li><span class="unicode" role="math">&#x29FB</span><span class="text">⧻</span><span class="name">Triple Plus</li>
+        <li><span class="unicode" role="math">&#x29FE</span><span class="text">⧾</span><span class="name">Tiny</li>
+        <li><span class="unicode" role="math">&#x29FF</span><span class="text">⧿</span><span class="name">Miny</li>
+        <li><span class="unicode" role="math">&#x2A00</span><span class="text">⨀</span><span class="name">N-Ary Circled Dot Operator</li>
+        <li><span class="unicode" role="math">&#x2A01</span><span class="text">⨁</span><span class="name">N-Ary Circled Plus Operator</li>
+        <li><span class="unicode" role="math">&#x2A02</span><span class="text">⨂</span><span class="name">N-Ary Circled Times Operator</li>
+        <li><span class="unicode" role="math">&#x2A03</span><span class="text">⨃</span><span class="name">N-Ary Union Operator with Dot</li>
+        <li><span class="unicode" role="math">&#x2A04</span><span class="text">⨄</span><span class="name">N-Ary Union Operator with Plus</li>
+        <li><span class="unicode" role="math">&#x2A05</span><span class="text">⨅</span><span class="name">N-Ary Square Intersection Operator</li>
+        <li><span class="unicode" role="math">&#x2A06</span><span class="text">⨆</span><span class="name">N-Ary Square Union Operator</li>
+        <li><span class="unicode" role="math">&#x2A07</span><span class="text">⨇</span><span class="name">Two Logical and Operator</li>
+        <li><span class="unicode" role="math">&#x2A08</span><span class="text">⨈</span><span class="name">Two Logical or Operator</li>
+        <li><span class="unicode" role="math">&#x2A09</span><span class="text">⨉</span><span class="name">N-Ary Times Operator</li>
+        <li><span class="unicode" role="math">&#x2A0A</span><span class="text">⨊</span><span class="name">Modulo Two Sum</li>
+        <li><span class="unicode" role="math">&#x2A0B</span><span class="text">⨋</span><span class="name">Summation with Integral</li>
+        <li><span class="unicode" role="math">&#x2A0C</span><span class="text">⨌</span><span class="name">Quadruple Integral Operator</li>
+        <li><span class="unicode" role="math">&#x2A0D</span><span class="text">⨍</span><span class="name">Finite Part Integral</li>
+        <li><span class="unicode" role="math">&#x2A0E</span><span class="text">⨎</span><span class="name">Integral with Double Stroke</li>
+        <li><span class="unicode" role="math">&#x2A0F</span><span class="text">⨏</span><span class="name">Integral Average with Slash</li>
+        <li><span class="unicode" role="math">&#x2A10</span><span class="text">⨐</span><span class="name">Circulation Function</li>
+        <li><span class="unicode" role="math">&#x2A11</span><span class="text">⨑</span><span class="name">Anticlockwise Integration</li>
+        <li><span class="unicode" role="math">&#x2A12</span><span class="text">⨒</span><span class="name">Line Integration with Rectangular Path Around Pole</li>
+        <li><span class="unicode" role="math">&#x2A13</span><span class="text">⨓</span><span class="name">Line Integration with Semicircular Path Around Pole</li>
+        <li><span class="unicode" role="math">&#x2A14</span><span class="text">⨔</span><span class="name">Line Integration Not Including the Pole</li>
+        <li><span class="unicode" role="math">&#x2A15</span><span class="text">⨕</span><span class="name">Integral Around A Point Operator</li>
+        <li><span class="unicode" role="math">&#x2A16</span><span class="text">⨖</span><span class="name">Quaternion Integral Operator</li>
+        <li><span class="unicode" role="math">&#x2A17</span><span class="text">⨗</span><span class="name">Integral with Leftwards Arrow with Hook</li>
+        <li><span class="unicode" role="math">&#x2A18</span><span class="text">⨘</span><span class="name">Integral with Times Sign</li>
+        <li><span class="unicode" role="math">&#x2A19</span><span class="text">⨙</span><span class="name">Integral with Intersection</li>
+        <li><span class="unicode" role="math">&#x2A1A</span><span class="text">⨚</span><span class="name">Integral with Union</li>
+        <li><span class="unicode" role="math">&#x2A1B</span><span class="text">⨛</span><span class="name">Integral with Overbar</li>
+        <li><span class="unicode" role="math">&#x2A1C</span><span class="text">⨜</span><span class="name">Integral with Underbar</li>
+        <li><span class="unicode" role="math">&#x2A1D</span><span class="text">⨝</span><span class="name">Join</li>
+        <li><span class="unicode" role="math">&#x2A1E</span><span class="text">⨞</span><span class="name">Large Left Triangle Operator</li>
+        <li><span class="unicode" role="math">&#x2A1F</span><span class="text">⨟</span><span class="name">Z Notation Schema Composition</li>
+        <li><span class="unicode" role="math">&#x2A20</span><span class="text">⨠</span><span class="name">Z Notation Schema Piping</li>
+        <li><span class="unicode" role="math">&#x2A21</span><span class="text">⨡</span><span class="name">Z Notation Schema Projection</li>
+        <li><span class="unicode" role="math">&#x2A22</span><span class="text">⨢</span><span class="name">Plus Sign with Small Circle Above</li>
+        <li><span class="unicode" role="math">&#x2A23</span><span class="text">⨣</span><span class="name">Plus Sign with Circumflex Accent Above</li>
+        <li><span class="unicode" role="math">&#x2A24</span><span class="text">⨤</span><span class="name">Plus Sign with Tilde Above</li>
+        <li><span class="unicode" role="math">&#x2A25</span><span class="text">⨥</span><span class="name">Plus Sign with Dot Below</li>
+        <li><span class="unicode" role="math">&#x2A26</span><span class="text">⨦</span><span class="name">Plus Sign with Tilde Below</li>
+        <li><span class="unicode" role="math">&#x2A27</span><span class="text">⨧</span><span class="name">Plus Sign with Subscript Two</li>
+        <li><span class="unicode" role="math">&#x2A28</span><span class="text">⨨</span><span class="name">Plus Sign with Black Triangle</li>
+        <li><span class="unicode" role="math">&#x2A29</span><span class="text">⨩</span><span class="name">Minus Sign with Comma Above</li>
+        <li><span class="unicode" role="math">&#x2A2A</span><span class="text">⨪</span><span class="name">Minus Sign with Dot Below</li>
+        <li><span class="unicode" role="math">&#x2A2B</span><span class="text">⨫</span><span class="name">Minus Sign with Falling Dots</li>
+        <li><span class="unicode" role="math">&#x2A2C</span><span class="text">⨬</span><span class="name">Minus Sign with Rising Dots</li>
+        <li><span class="unicode" role="math">&#x2A2D</span><span class="text">⨭</span><span class="name">Plus Sign In Left Half Circle</li>
+        <li><span class="unicode" role="math">&#x2A2E</span><span class="text">⨮</span><span class="name">Plus Sign In Right Half Circle</li>
+        <li><span class="unicode" role="math">&#x2A2F</span><span class="text">⨯</span><span class="name">Vector or Cross Product</li>
+        <li><span class="unicode" role="math">&#x2A30</span><span class="text">⨰</span><span class="name">Multiplication Sign with Dot Above</li>
+        <li><span class="unicode" role="math">&#x2A31</span><span class="text">⨱</span><span class="name">Multiplication Sign with Underbar</li>
+        <li><span class="unicode" role="math">&#x2A32</span><span class="text">⨲</span><span class="name">Semidirect Product with Bottom Closed</li>
+        <li><span class="unicode" role="math">&#x2A33</span><span class="text">⨳</span><span class="name">Smash Product</li>
+        <li><span class="unicode" role="math">&#x2A34</span><span class="text">⨴</span><span class="name">Multiplication Sign In Left Half Circle</li>
+        <li><span class="unicode" role="math">&#x2A35</span><span class="text">⨵</span><span class="name">Multiplication Sign In Right Half Circle</li>
+        <li><span class="unicode" role="math">&#x2A36</span><span class="text">⨶</span><span class="name">Circled Multiplication Sign with Circumflex Accent</li>
+        <li><span class="unicode" role="math">&#x2A37</span><span class="text">⨷</span><span class="name">Multiplication Sign In Double Circle</li>
+        <li><span class="unicode" role="math">&#x2A38</span><span class="text">⨸</span><span class="name">Circled Division Sign</li>
+        <li><span class="unicode" role="math">&#x2A39</span><span class="text">⨹</span><span class="name">Plus Sign In Triangle</li>
+        <li><span class="unicode" role="math">&#x2A3A</span><span class="text">⨺</span><span class="name">Minus Sign In Triangle</li>
+        <li><span class="unicode" role="math">&#x2A3B</span><span class="text">⨻</span><span class="name">Multiplication Sign In Triangle</li>
+        <li><span class="unicode" role="math">&#x2A3C</span><span class="text">⨼</span><span class="name">Interior Product</li>
+        <li><span class="unicode" role="math">&#x2A3D</span><span class="text">⨽</span><span class="name">Righthand Interior Product</li>
+        <li><span class="unicode" role="math">&#x2A3E</span><span class="text">⨾</span><span class="name">Z Notation Relational Composition</li>
+        <li><span class="unicode" role="math">&#x2A3F</span><span class="text">⨿</span><span class="name">Amalgamation or Coproduct</li>
+        <li><span class="unicode" role="math">&#x2A40</span><span class="text">⩀</span><span class="name">Intersection with Dot</li>
+        <li><span class="unicode" role="math">&#x2A41</span><span class="text">⩁</span><span class="name">Union with Minus Sign</li>
+        <li><span class="unicode" role="math">&#x2A42</span><span class="text">⩂</span><span class="name">Union with Overbar</li>
+        <li><span class="unicode" role="math">&#x2A43</span><span class="text">⩃</span><span class="name">Intersection with Overbar</li>
+        <li><span class="unicode" role="math">&#x2A44</span><span class="text">⩄</span><span class="name">Intersection with Logical And</li>
+        <li><span class="unicode" role="math">&#x2A45</span><span class="text">⩅</span><span class="name">Union with Logical Or</li>
+        <li><span class="unicode" role="math">&#x2A46</span><span class="text">⩆</span><span class="name">Union Above Intersection</li>
+        <li><span class="unicode" role="math">&#x2A47</span><span class="text">⩇</span><span class="name">Intersection Above Union</li>
+        <li><span class="unicode" role="math">&#x2A48</span><span class="text">⩈</span><span class="name">Union Above Bar Above Intersection</li>
+        <li><span class="unicode" role="math">&#x2A49</span><span class="text">⩉</span><span class="name">Intersection Above Bar Above Union</li>
+        <li><span class="unicode" role="math">&#x2A4A</span><span class="text">⩊</span><span class="name">Union Beside and Joined with Union</li>
+        <li><span class="unicode" role="math">&#x2A4B</span><span class="text">⩋</span><span class="name">Intersection Beside and Joined with Intersection</li>
+        <li><span class="unicode" role="math">&#x2A4C</span><span class="text">⩌</span><span class="name">Closed Union with Serifs</li>
+        <li><span class="unicode" role="math">&#x2A4D</span><span class="text">⩍</span><span class="name">Closed Intersection with Serifs</li>
+        <li><span class="unicode" role="math">&#x2A4E</span><span class="text">⩎</span><span class="name">Double Square Intersection</li>
+        <li><span class="unicode" role="math">&#x2A4F</span><span class="text">⩏</span><span class="name">Double Square Union</li>
+        <li><span class="unicode" role="math">&#x2A50</span><span class="text">⩐</span><span class="name">Closed Union with Serifs and Smash Product</li>
+        <li><span class="unicode" role="math">&#x2A51</span><span class="text">⩑</span><span class="name">Logical and with Dot Above</li>
+        <li><span class="unicode" role="math">&#x2A52</span><span class="text">⩒</span><span class="name">Logical or with Dot Above</li>
+        <li><span class="unicode" role="math">&#x2A53</span><span class="text">⩓</span><span class="name">Double Logical And</li>
+        <li><span class="unicode" role="math">&#x2A54</span><span class="text">⩔</span><span class="name">Double Logical Or</li>
+        <li><span class="unicode" role="math">&#x2A55</span><span class="text">⩕</span><span class="name">Two Intersecting Logical And</li>
+        <li><span class="unicode" role="math">&#x2A56</span><span class="text">⩖</span><span class="name">Two Intersecting Logical Or</li>
+        <li><span class="unicode" role="math">&#x2A57</span><span class="text">⩗</span><span class="name">Sloping Large Or</li>
+        <li><span class="unicode" role="math">&#x2A58</span><span class="text">⩘</span><span class="name">Sloping Large And</li>
+        <li><span class="unicode" role="math">&#x2A59</span><span class="text">⩙</span><span class="name">Logical or Overlapping Logical And</li>
+        <li><span class="unicode" role="math">&#x2A5A</span><span class="text">⩚</span><span class="name">Logical and with Middle Stem</li>
+        <li><span class="unicode" role="math">&#x2A5B</span><span class="text">⩛</span><span class="name">Logical or with Middle Stem</li>
+        <li><span class="unicode" role="math">&#x2A5C</span><span class="text">⩜</span><span class="name">Logical and with Horizontal Dash</li>
+        <li><span class="unicode" role="math">&#x2A5D</span><span class="text">⩝</span><span class="name">Logical or with Horizontal Dash</li>
+        <li><span class="unicode" role="math">&#x2A5E</span><span class="text">⩞</span><span class="name">Logical and with Double Overbar</li>
+        <li><span class="unicode" role="math">&#x2A5F</span><span class="text">⩟</span><span class="name">Logical and with Underbar</li>
+        <li><span class="unicode" role="math">&#x2A60</span><span class="text">⩠</span><span class="name">Logical and with Double Underbar</li>
+        <li><span class="unicode" role="math">&#x2A61</span><span class="text">⩡</span><span class="name">Small Vee with Underbar</li>
+        <li><span class="unicode" role="math">&#x2A62</span><span class="text">⩢</span><span class="name">Logical or with Double Overbar</li>
+        <li><span class="unicode" role="math">&#x2A63</span><span class="text">⩣</span><span class="name">Logical or with Double Underbar</li>
+        <li><span class="unicode" role="math">&#x2A64</span><span class="text">⩤</span><span class="name">Z Notation Domain Antirestriction</li>
+        <li><span class="unicode" role="math">&#x2A65</span><span class="text">⩥</span><span class="name">Z Notation Range Antirestriction</li>
+        <li><span class="unicode" role="math">&#x2A66</span><span class="text">⩦</span><span class="name">Equals Sign with Dot Below</li>
+        <li><span class="unicode" role="math">&#x2A67</span><span class="text">⩧</span><span class="name">Identical with Dot Above</li>
+        <li><span class="unicode" role="math">&#x2A68</span><span class="text">⩨</span><span class="name">Triple Horizontal Bar with Double Vertical Stroke</li>
+        <li><span class="unicode" role="math">&#x2A69</span><span class="text">⩩</span><span class="name">Triple Horizontal Bar with Triple Vertical Stroke</li>
+        <li><span class="unicode" role="math">&#x2A6A</span><span class="text">⩪</span><span class="name">Tilde Operator with Dot Above</li>
+        <li><span class="unicode" role="math">&#x2A6B</span><span class="text">⩫</span><span class="name">Tilde Operator with Rising Dots</li>
+        <li><span class="unicode" role="math">&#x2A6C</span><span class="text">⩬</span><span class="name">Similar Minus Similar</li>
+        <li><span class="unicode" role="math">&#x2A6D</span><span class="text">⩭</span><span class="name">Congruent with Dot Above</li>
+        <li><span class="unicode" role="math">&#x2A6E</span><span class="text">⩮</span><span class="name">Equals with Asterisk</li>
+        <li><span class="unicode" role="math">&#x2A6F</span><span class="text">⩯</span><span class="name">Almost Equal to with Circumflex Accent</li>
+        <li><span class="unicode" role="math">&#x2A70</span><span class="text">⩰</span><span class="name">Approximately Equal or Equal To</li>
+        <li><span class="unicode" role="math">&#x2A71</span><span class="text">⩱</span><span class="name">Equals Sign Above Plus Sign</li>
+        <li><span class="unicode" role="math">&#x2A72</span><span class="text">⩲</span><span class="name">Plus Sign Above Equals Sign</li>
+        <li><span class="unicode" role="math">&#x2A73</span><span class="text">⩳</span><span class="name">Equals Sign Above Tilde Operator</li>
+        <li><span class="unicode" role="math">&#x2A74</span><span class="text">⩴</span><span class="name">Double Colon Equal</li>
+        <li><span class="unicode" role="math">&#x2A75</span><span class="text">⩵</span><span class="name">Two Consecutive Equals Signs</li>
+        <li><span class="unicode" role="math">&#x2A76</span><span class="text">⩶</span><span class="name">Three Consecutive Equals Signs</li>
+        <li><span class="unicode" role="math">&#x2A77</span><span class="text">⩷</span><span class="name">Equals Sign with Two Dots Above and Two Dots Below</li>
+        <li><span class="unicode" role="math">&#x2A78</span><span class="text">⩸</span><span class="name">Equivalent with Four Dots Above</li>
+        <li><span class="unicode" role="math">&#x2A79</span><span class="text">⩹</span><span class="name">Less-Than with Circle Inside</li>
+        <li><span class="unicode" role="math">&#x2A7A</span><span class="text">⩺</span><span class="name">Greater-Than with Circle Inside</li>
+        <li><span class="unicode" role="math">&#x2A7B</span><span class="text">⩻</span><span class="name">Less-Than with Question Mark Above</li>
+        <li><span class="unicode" role="math">&#x2A7C</span><span class="text">⩼</span><span class="name">Greater-Than with Question Mark Above</li>
+        <li><span class="unicode" role="math">&#x2A7D</span><span class="text">⩽</span><span class="name">Less-Than or Slanted Equal To</li>
+        <li><span class="unicode" role="math">&#x2A7E</span><span class="text">⩾</span><span class="name">Greater-Than or Slanted Equal To</li>
+        <li><span class="unicode" role="math">&#x2A7F</span><span class="text">⩿</span><span class="name">Less-Than or Slanted Equal to with Dot Inside</li>
+        <li><span class="unicode" role="math">&#x2A80</span><span class="text">⪀</span><span class="name">Greater-Than or Slanted Equal to with Dot Inside</li>
+        <li><span class="unicode" role="math">&#x2A81</span><span class="text">⪁</span><span class="name">Less-Than or Slanted Equal to with Dot Above</li>
+        <li><span class="unicode" role="math">&#x2A82</span><span class="text">⪂</span><span class="name">Greater-Than or Slanted Equal to with Dot Above</li>
+        <li><span class="unicode" role="math">&#x2A83</span><span class="text">⪃</span><span class="name">Less-Than or Slanted Equal to with Dot Above Right</li>
+        <li><span class="unicode" role="math">&#x2A84</span><span class="text">⪄</span><span class="name">Greater-Than or Slanted Equal to with Dot Above Left</li>
+        <li><span class="unicode" role="math">&#x2A85</span><span class="text">⪅</span><span class="name">Less-Than or Approximate</li>
+        <li><span class="unicode" role="math">&#x2A86</span><span class="text">⪆</span><span class="name">Greater-Than or Approximate</li>
+        <li><span class="unicode" role="math">&#x2A87</span><span class="text">⪇</span><span class="name">Less-Than and Single-Line Not Equal To</li>
+        <li><span class="unicode" role="math">&#x2A88</span><span class="text">⪈</span><span class="name">Greater-Than and Single-Line Not Equal To</li>
+        <li><span class="unicode" role="math">&#x2A89</span><span class="text">⪉</span><span class="name">Less-Than and Not Approximate</li>
+        <li><span class="unicode" role="math">&#x2A8A</span><span class="text">⪊</span><span class="name">Greater-Than and Not Approximate</li>
+        <li><span class="unicode" role="math">&#x2A8B</span><span class="text">⪋</span><span class="name">Less-Than Above Double-Line Equal Above Greater-Than</li>
+        <li><span class="unicode" role="math">&#x2A8C</span><span class="text">⪌</span><span class="name">Greater-Than Above Double-Line Equal Above Less-Than</li>
+        <li><span class="unicode" role="math">&#x2A8D</span><span class="text">⪍</span><span class="name">Less-Than Above Similar or Equal</li>
+        <li><span class="unicode" role="math">&#x2A8E</span><span class="text">⪎</span><span class="name">Greater-Than Above Similar or Equal</li>
+        <li><span class="unicode" role="math">&#x2A8F</span><span class="text">⪏</span><span class="name">Less-Than Above Similar Above Greater-Than</li>
+        <li><span class="unicode" role="math">&#x2A90</span><span class="text">⪐</span><span class="name">Greater-Than Above Similar Above Less-Than</li>
+        <li><span class="unicode" role="math">&#x2A91</span><span class="text">⪑</span><span class="name">Less-Than Above Greater-Than Above Double-Line Equal</li>
+        <li><span class="unicode" role="math">&#x2A92</span><span class="text">⪒</span><span class="name">Greater-Than Above Less-Than Above Double-Line Equal</li>
+        <li><span class="unicode" role="math">&#x2A93</span><span class="text">⪓</span><span class="name">Less-Than Above Slanted Equal Above Greater-Than Above Slanted Equal</li>
+        <li><span class="unicode" role="math">&#x2A94</span><span class="text">⪔</span><span class="name">Greater-Than Above Slanted Equal Above Less-Than Above Slanted Equal</li>
+        <li><span class="unicode" role="math">&#x2A95</span><span class="text">⪕</span><span class="name">Slanted Equal to or Less-Than</li>
+        <li><span class="unicode" role="math">&#x2A96</span><span class="text">⪖</span><span class="name">Slanted Equal to or Greater-Than</li>
+        <li><span class="unicode" role="math">&#x2A97</span><span class="text">⪗</span><span class="name">Slanted Equal to or Less-Than with Dot Inside</li>
+        <li><span class="unicode" role="math">&#x2A98</span><span class="text">⪘</span><span class="name">Slanted Equal to or Greater-Than with Dot Inside</li>
+        <li><span class="unicode" role="math">&#x2A99</span><span class="text">⪙</span><span class="name">Double-Line Equal to or Less-Than</li>
+        <li><span class="unicode" role="math">&#x2A9A</span><span class="text">⪚</span><span class="name">Double-Line Equal to or Greater-Than</li>
+        <li><span class="unicode" role="math">&#x2A9B</span><span class="text">⪛</span><span class="name">Double-Line Slanted Equal to or Less-Than</li>
+        <li><span class="unicode" role="math">&#x2A9C</span><span class="text">⪜</span><span class="name">Double-Line Slanted Equal to or Greater-Than</li>
+        <li><span class="unicode" role="math">&#x2A9D</span><span class="text">⪝</span><span class="name">Similar or Less-Than</li>
+        <li><span class="unicode" role="math">&#x2A9E</span><span class="text">⪞</span><span class="name">Similar or Greater-Than</li>
+        <li><span class="unicode" role="math">&#x2A9F</span><span class="text">⪟</span><span class="name">Similar Above Less-Than Above Equals Sign</li>
+        <li><span class="unicode" role="math">&#x2AA0</span><span class="text">⪠</span><span class="name">Similar Above Greater-Than Above Equals Sign</li>
+        <li><span class="unicode" role="math">&#x2AA1</span><span class="text">⪡</span><span class="name">Double Nested Less-Than</li>
+        <li><span class="unicode" role="math">&#x2AA2</span><span class="text">⪢</span><span class="name">Double Nested Greater-Than</li>
+        <li><span class="unicode" role="math">&#x2AA3</span><span class="text">⪣</span><span class="name">Double Nested Less-Than with Underbar</li>
+        <li><span class="unicode" role="math">&#x2AA4</span><span class="text">⪤</span><span class="name">Greater-Than Overlapping Less-Than</li>
+        <li><span class="unicode" role="math">&#x2AA5</span><span class="text">⪥</span><span class="name">Greater-Than Beside Less-Than</li>
+        <li><span class="unicode" role="math">&#x2AA6</span><span class="text">⪦</span><span class="name">Less-Than Closed By Curve</li>
+        <li><span class="unicode" role="math">&#x2AA7</span><span class="text">⪧</span><span class="name">Greater-Than Closed By Curve</li>
+        <li><span class="unicode" role="math">&#x2AA8</span><span class="text">⪨</span><span class="name">Less-Than Closed By Curve Above Slanted Equal</li>
+        <li><span class="unicode" role="math">&#x2AA9</span><span class="text">⪩</span><span class="name">Greater-Than Closed By Curve Above Slanted Equal</li>
+        <li><span class="unicode" role="math">&#x2AAA</span><span class="text">⪪</span><span class="name">Smaller Than</li>
+        <li><span class="unicode" role="math">&#x2AAB</span><span class="text">⪫</span><span class="name">Larger Than</li>
+        <li><span class="unicode" role="math">&#x2AAC</span><span class="text">⪬</span><span class="name">Smaller Than or Equal To</li>
+        <li><span class="unicode" role="math">&#x2AAD</span><span class="text">⪭</span><span class="name">Larger Than or Equal To</li>
+        <li><span class="unicode" role="math">&#x2AAE</span><span class="text">⪮</span><span class="name">Equals Sign with Bumpy Above</li>
+        <li><span class="unicode" role="math">&#x2AAF</span><span class="text">⪯</span><span class="name">Precedes Above Single-Line Equals Sign</li>
+        <li><span class="unicode" role="math">&#x2AB0</span><span class="text">⪰</span><span class="name">Succeeds Above Single-Line Equals Sign</li>
+        <li><span class="unicode" role="math">&#x2AB1</span><span class="text">⪱</span><span class="name">Precedes Above Single-Line Not Equal To</li>
+        <li><span class="unicode" role="math">&#x2AB2</span><span class="text">⪲</span><span class="name">Succeeds Above Single-Line Not Equal To</li>
+        <li><span class="unicode" role="math">&#x2AB3</span><span class="text">⪳</span><span class="name">Precedes Above Equals Sign</li>
+        <li><span class="unicode" role="math">&#x2AB4</span><span class="text">⪴</span><span class="name">Succeeds Above Equals Sign</li>
+        <li><span class="unicode" role="math">&#x2AB5</span><span class="text">⪵</span><span class="name">Precedes Above Not Equal To</li>
+        <li><span class="unicode" role="math">&#x2AB6</span><span class="text">⪶</span><span class="name">Succeeds Above Not Equal To</li>
+        <li><span class="unicode" role="math">&#x2AB7</span><span class="text">⪷</span><span class="name">Precedes Above Almost Equal To</li>
+        <li><span class="unicode" role="math">&#x2AB8</span><span class="text">⪸</span><span class="name">Succeeds Above Almost Equal To</li>
+        <li><span class="unicode" role="math">&#x2AB9</span><span class="text">⪹</span><span class="name">Precedes Above Not Almost Equal To</li>
+        <li><span class="unicode" role="math">&#x2ABA</span><span class="text">⪺</span><span class="name">Succeeds Above Not Almost Equal To</li>
+        <li><span class="unicode" role="math">&#x2ABB</span><span class="text">⪻</span><span class="name">Double Precedes</li>
+        <li><span class="unicode" role="math">&#x2ABC</span><span class="text">⪼</span><span class="name">Double Succeeds</li>
+        <li><span class="unicode" role="math">&#x2ABD</span><span class="text">⪽</span><span class="name">Subset with Dot</li>
+        <li><span class="unicode" role="math">&#x2ABE</span><span class="text">⪾</span><span class="name">Superset with Dot</li>
+        <li><span class="unicode" role="math">&#x2ABF</span><span class="text">⪿</span><span class="name">Subset with Plus Sign Below</li>
+        <li><span class="unicode" role="math">&#x2AC0</span><span class="text">⫀</span><span class="name">Superset with Plus Sign Below</li>
+        <li><span class="unicode" role="math">&#x2AC1</span><span class="text">⫁</span><span class="name">Subset with Multiplication Sign Below</li>
+        <li><span class="unicode" role="math">&#x2AC2</span><span class="text">⫂</span><span class="name">Superset with Multiplication Sign Below</li>
+        <li><span class="unicode" role="math">&#x2AC3</span><span class="text">⫃</span><span class="name">Subset of or Equal to with Dot Above</li>
+        <li><span class="unicode" role="math">&#x2AC4</span><span class="text">⫄</span><span class="name">Superset of or Equal to with Dot Above</li>
+        <li><span class="unicode" role="math">&#x2AC5</span><span class="text">⫅</span><span class="name">Subset of Above Equals Sign</li>
+        <li><span class="unicode" role="math">&#x2AC6</span><span class="text">⫆</span><span class="name">Superset of Above Equals Sign</li>
+        <li><span class="unicode" role="math">&#x2AC7</span><span class="text">⫇</span><span class="name">Subset of Above Tilde Operator</li>
+        <li><span class="unicode" role="math">&#x2AC8</span><span class="text">⫈</span><span class="name">Superset of Above Tilde Operator</li>
+        <li><span class="unicode" role="math">&#x2AC9</span><span class="text">⫉</span><span class="name">Subset of Above Almost Equal To</li>
+        <li><span class="unicode" role="math">&#x2ACA</span><span class="text">⫊</span><span class="name">Superset of Above Almost Equal To</li>
+        <li><span class="unicode" role="math">&#x2ACB</span><span class="text">⫋</span><span class="name">Subset of Above Not Equal To</li>
+        <li><span class="unicode" role="math">&#x2ACC</span><span class="text">⫌</span><span class="name">Superset of Above Not Equal To</li>
+        <li><span class="unicode" role="math">&#x2ACD</span><span class="text">⫍</span><span class="name">Square Left Open Box Operator</li>
+        <li><span class="unicode" role="math">&#x2ACE</span><span class="text">⫎</span><span class="name">Square Right Open Box Operator</li>
+        <li><span class="unicode" role="math">&#x2ACF</span><span class="text">⫏</span><span class="name">Closed Subset</li>
+        <li><span class="unicode" role="math">&#x2AD0</span><span class="text">⫐</span><span class="name">Closed Superset</li>
+        <li><span class="unicode" role="math">&#x2AD1</span><span class="text">⫑</span><span class="name">Closed Subset or Equal To</li>
+        <li><span class="unicode" role="math">&#x2AD2</span><span class="text">⫒</span><span class="name">Closed Superset or Equal To</li>
+        <li><span class="unicode" role="math">&#x2AD3</span><span class="text">⫓</span><span class="name">Subset Above Superset</li>
+        <li><span class="unicode" role="math">&#x2AD4</span><span class="text">⫔</span><span class="name">Superset Above Subset</li>
+        <li><span class="unicode" role="math">&#x2AD5</span><span class="text">⫕</span><span class="name">Subset Above Subset</li>
+        <li><span class="unicode" role="math">&#x2AD6</span><span class="text">⫖</span><span class="name">Superset Above Superset</li>
+        <li><span class="unicode" role="math">&#x2AD7</span><span class="text">⫗</span><span class="name">Superset Beside Subset</li>
+        <li><span class="unicode" role="math">&#x2AD8</span><span class="text">⫘</span><span class="name">Superset Beside and Joined By Dash with Subset</li>
+        <li><span class="unicode" role="math">&#x2AD9</span><span class="text">⫙</span><span class="name">Element of Opening Downwards</li>
+        <li><span class="unicode" role="math">&#x2ADA</span><span class="text">⫚</span><span class="name">Pitchfork with Tee Top</li>
+        <li><span class="unicode" role="math">&#x2ADB</span><span class="text">⫛</span><span class="name">Transversal Intersection</li>
+        <li><span class="unicode" role="math">&#x2ADC</span><span class="text">⫝̸</span><span class="name">Forking</li>
+        <li><span class="unicode" role="math">&#x2ADD</span><span class="text">⫝</span><span class="name">Nonforking</li>
+        <li><span class="unicode" role="math">&#x2ADE</span><span class="text">⫞</span><span class="name">Short Left Tack</li>
+        <li><span class="unicode" role="math">&#x2ADF</span><span class="text">⫟</span><span class="name">Short Down Tack</li>
+        <li><span class="unicode" role="math">&#x2AE0</span><span class="text">⫠</span><span class="name">Short Up Tack</li>
+        <li><span class="unicode" role="math">&#x2AE1</span><span class="text">⫡</span><span class="name">Perpendicular with S</li>
+        <li><span class="unicode" role="math">&#x2AE2</span><span class="text">⫢</span><span class="name">Vertical Bar Triple Right Turnstile</li>
+        <li><span class="unicode" role="math">&#x2AE3</span><span class="text">⫣</span><span class="name">Double Vertical Bar Left Turnstile</li>
+        <li><span class="unicode" role="math">&#x2AE4</span><span class="text">⫤</span><span class="name">Vertical Bar Double Left Turnstile</li>
+        <li><span class="unicode" role="math">&#x2AE5</span><span class="text">⫥</span><span class="name">Double Vertical Bar Double Left Turnstile</li>
+        <li><span class="unicode" role="math">&#x2AE6</span><span class="text">⫦</span><span class="name">Long Dash from Left Member of Double Vertical</li>
+        <li><span class="unicode" role="math">&#x2AE7</span><span class="text">⫧</span><span class="name">Short Down Tack with Overbar</li>
+        <li><span class="unicode" role="math">&#x2AE8</span><span class="text">⫨</span><span class="name">Short Up Tack with Underbar</li>
+        <li><span class="unicode" role="math">&#x2AE9</span><span class="text">⫩</span><span class="name">Short Up Tack Above Short Down Tack</li>
+        <li><span class="unicode" role="math">&#x2AEA</span><span class="text">⫪</span><span class="name">Double Down Tack</li>
+        <li><span class="unicode" role="math">&#x2AEB</span><span class="text">⫫</span><span class="name">Double Up Tack</li>
+        <li><span class="unicode" role="math">&#x2AEC</span><span class="text">⫬</span><span class="name">Double Stroke Not Sign</li>
+        <li><span class="unicode" role="math">&#x2AED</span><span class="text">⫭</span><span class="name">Reversed Double Stroke Not Sign</li>
+        <li><span class="unicode" role="math">&#x2AEE</span><span class="text">⫮</span><span class="name">Does Not Divide with Reversed Negation Slash</li>
+        <li><span class="unicode" role="math">&#x2AEF</span><span class="text">⫯</span><span class="name">Vertical Line with Circle Above</li>
+        <li><span class="unicode" role="math">&#x2AF0</span><span class="text">⫰</span><span class="name">Vertical Line with Circle Below</li>
+        <li><span class="unicode" role="math">&#x2AF1</span><span class="text">⫱</span><span class="name">Down Tack with Circle Below</li>
+        <li><span class="unicode" role="math">&#x2AF2</span><span class="text">⫲</span><span class="name">Parallel with Horizontal Stroke</li>
+        <li><span class="unicode" role="math">&#x2AF3</span><span class="text">⫳</span><span class="name">Parallel with Tilde Operator</li>
+        <li><span class="unicode" role="math">&#x2AF4</span><span class="text">⫴</span><span class="name">Triple Vertical Bar Binary Relation</li>
+        <li><span class="unicode" role="math">&#x2AF5</span><span class="text">⫵</span><span class="name">Triple Vertical Bar with Horizontal Stroke</li>
+        <li><span class="unicode" role="math">&#x2AF6</span><span class="text">⫶</span><span class="name">Triple Colon Operator</li>
+        <li><span class="unicode" role="math">&#x2AF7</span><span class="text">⫷</span><span class="name">Triple Nested Less-Than</li>
+        <li><span class="unicode" role="math">&#x2AF8</span><span class="text">⫸</span><span class="name">Triple Nested Greater-Than</li>
+        <li><span class="unicode" role="math">&#x2AF9</span><span class="text">⫹</span><span class="name">Double-Line Slanted Less-Than or Equal To</li>
+        <li><span class="unicode" role="math">&#x2AFA</span><span class="text">⫺</span><span class="name">Double-Line Slanted Greater-Than or Equal To</li>
+        <li><span class="unicode" role="math">&#x2AFB</span><span class="text">⫻</span><span class="name">Triple Solidus Binary Relation</li>
+        <li><span class="unicode" role="math">&#x2AFC</span><span class="text">⫼</span><span class="name">Large Triple Vertical Bar Operator</li>
+        <li><span class="unicode" role="math">&#x2AFD</span><span class="text">⫽</span><span class="name">Double Solidus Operator</li>
+        <li><span class="unicode" role="math">&#x2AFE</span><span class="text">⫾</span><span class="name">White Vertical Bar</li>
+        <li><span class="unicode" role="math">&#x2AFF</span><span class="text">⫿</span><span class="name">N-Ary White Vertical Bar</li>
+        <li><span class="unicode" role="math">&#x2B30</span><span class="text">⬰</span><span class="name">Left Arrow with Small Circle</li>
+        <li><span class="unicode" role="math">&#x2B31</span><span class="text">⬱</span><span class="name">Three Leftwards Arrows</li>
+        <li><span class="unicode" role="math">&#x2B32</span><span class="text">⬲</span><span class="name">Left Arrow with Circled Plus</li>
+        <li><span class="unicode" role="math">&#x2B33</span><span class="text">⬳</span><span class="name">Long Leftwards Squiggle Arrow</li>
+        <li><span class="unicode" role="math">&#x2B34</span><span class="text">⬴</span><span class="name">Leftwards Two-Headed Arrow with Vertical Stroke</li>
+        <li><span class="unicode" role="math">&#x2B35</span><span class="text">⬵</span><span class="name">Leftwards Two-Headed Arrow with Double Vertical Stroke</li>
+        <li><span class="unicode" role="math">&#x2B36</span><span class="text">⬶</span><span class="name">Leftwards Two-Headed Arrow from Bar</li>
+        <li><span class="unicode" role="math">&#x2B37</span><span class="text">⬷</span><span class="name">Leftwards Two-Headed Triple Dash Arrow</li>
+        <li><span class="unicode" role="math">&#x2B38</span><span class="text">⬸</span><span class="name">Leftwards Arrow with Dotted Stem</li>
+        <li><span class="unicode" role="math">&#x2B39</span><span class="text">⬹</span><span class="name">Leftwards Arrow with Tail with Vertical Stroke</li>
+        <li><span class="unicode" role="math">&#x2B3A</span><span class="text">⬺</span><span class="name">Leftwards Arrow with Tail with Double Vertical Stroke</li>
+        <li><span class="unicode" role="math">&#x2B3B</span><span class="text">⬻</span><span class="name">Leftwards Two-Headed Arrow with Tail</li>
+        <li><span class="unicode" role="math">&#x2B3C</span><span class="text">⬼</span><span class="name">Leftwards Two-Headed Arrow with Tail with Vertical Stroke</li>
+        <li><span class="unicode" role="math">&#x2B3D</span><span class="text">⬽</span><span class="name">Leftwards Two-Headed Arrow with Tail with Double Vertical Stroke</li>
+        <li><span class="unicode" role="math">&#x2B3E</span><span class="text">⬾</span><span class="name">Leftwards Arrow Through X</li>
+        <li><span class="unicode" role="math">&#x2B3F</span><span class="text">⬿</span><span class="name">Wave Arrow Pointing Directly Left</li>
+        <li><span class="unicode" role="math">&#x2B40</span><span class="text">⭀</span><span class="name">Equals Sign Above Leftwards Arrow</li>
+        <li><span class="unicode" role="math">&#x2B41</span><span class="text">⭁</span><span class="name">Reverse Tilde Operator Above Leftwards Arrow</li>
+        <li><span class="unicode" role="math">&#x2B42</span><span class="text">⭂</span><span class="name">Leftwards Arrow Above Reverse Almost Equal To</li>
+        <li><span class="unicode" role="math">&#x2B43</span><span class="text">⭃</span><span class="name">Rightwards Arrow Through Greater-Than</li>
+        <li><span class="unicode" role="math">&#x2B44</span><span class="text">⭄</span><span class="name">Rightwards Arrow Through Superset</li>
+        <li><span class="unicode" role="math">&#x2B47</span><span class="text">⭇</span><span class="name">Reverse Tilde Operator Above Rightwards Arrow</li>
+        <li><span class="unicode" role="math">&#x2B48</span><span class="text">⭈</span><span class="name">Rightwards Arrow Above Reverse Almost Equal To</li>
+        <li><span class="unicode" role="math">&#x2B49</span><span class="text">⭉</span><span class="name">Tilde Operator Above Leftwards Arrow</li>
+        <li><span class="unicode" role="math">&#x2B4A</span><span class="text">⭊</span><span class="name">Leftwards Arrow Above Almost Equal To</li>
+        <li><span class="unicode" role="math">&#x2B4B</span><span class="text">⭋</span><span class="name">Leftwards Arrow Above Reverse Tilde Operator</li>
+        <li><span class="unicode" role="math">&#x2B4C</span><span class="text">⭌</span><span class="name">Rightwards Arrow Above Reverse Tilde Operator</li>
+        <li><span class="unicode" role="math">&#xFB29</span><span class="text">﬩</span><span class="name">Hebrew Letter Alternative Plus Sign</li>
+        <li><span class="unicode" role="math">&#xFE62</span><span class="text">﹢</span><span class="name">Small Plus Sign</li>
+        <li><span class="unicode" role="math">&#xFE64</span><span class="text">﹤</span><span class="name">Small Less-Than Sign</li>
+        <li><span class="unicode" role="math">&#xFE65</span><span class="text">﹥</span><span class="name">Small Greater-Than Sign</li>
+        <li><span class="unicode" role="math">&#xFE66</span><span class="text">﹦</span><span class="name">Small Equals Sign</li>
+        <li><span class="unicode" role="math">&#xFF0B</span><span class="text">＋</span><span class="name">Fullwidth Plus Sign</li>
+        <li><span class="unicode" role="math">&#xFF1C</span><span class="text">＜</span><span class="name">Fullwidth Less-Than Sign</li>
+        <li><span class="unicode" role="math">&#xFF1D</span><span class="text">＝</span><span class="name">Fullwidth Equals Sign</li>
+        <li><span class="unicode" role="math">&#xFF1E</span><span class="text">＞</span><span class="name">Fullwidth Greater-Than Sign</li>
+        <li><span class="unicode" role="math">&#xFF5C</span><span class="text">｜</span><span class="name">Fullwidth Vertical Line</li>
+        <li><span class="unicode" role="math">&#xFF5E</span><span class="text">～</span><span class="name">Fullwidth Tilde</li>
+        <li><span class="unicode" role="math">&#xFFE2</span><span class="text">￢</span><span class="name">Fullwidth Not Sign</li>
+        <li><span class="unicode" role="math">&#xFFE9</span><span class="text">￩</span><span class="name">Halfwidth Leftwards Arrow</li>
+        <li><span class="unicode" role="math">&#xFFEA</span><span class="text">￪</span><span class="name">Halfwidth Upwards Arrow</li>
+        <li><span class="unicode" role="math">&#xFFEB</span><span class="text">￫</span><span class="name">Halfwidth Rightwards Arrow</li>
+        <li><span class="unicode" role="math">&#xFFEC</span><span class="text">￬</span><span class="name">Halfwidth Downwards Arrow</li>
+        <li><span class="unicode" role="math">&#x1D6C1</span><span class="text">𝛁</span><span class="name">Mathematical Bold Nabla</li>
+        <li><span class="unicode" role="math">&#x1D6DB</span><span class="text">𝛛</span><span class="name">Mathematical Bold Partial Differential</li>
+        <li><span class="unicode" role="math">&#x1D6FB</span><span class="text">𝛻</span><span class="name">Mathematical Italic Nabla</li>
+        <li><span class="unicode" role="math">&#x1D715</span><span class="text">𝜕</span><span class="name">Mathematical Italic Partial Differential</li>
+        <li><span class="unicode" role="math">&#x1D735</span><span class="text">𝜵</span><span class="name">Mathematical Bold Italic Nabla</li>
+        <li><span class="unicode" role="math">&#x1D74F</span><span class="text">𝝏</span><span class="name">Mathematical Bold Italic Partial Differential</li>
+        <li><span class="unicode" role="math">&#x1D76F</span><span class="text">𝝯</span><span class="name">Mathematical Sans-Serif Bold Nabla</li>
+        <li><span class="unicode" role="math">&#x1D789</span><span class="text">𝞉</span><span class="name">Mathematical Sans-Serif Bold Partial Differential</li>
+        <li><span class="unicode" role="math">&#x1D7A9</span><span class="text">𝞩</span><span class="name">Mathematical Sans-Serif Bold Italic Nabla</li>
+        <li><span class="unicode" role="math">&#x1D7C3</span><span class="text">𝟃</span><span class="name">Mathematical Sans-Serif Bold Italic Partial Differential</li>
+        <li><span class="unicode" role="math">&#x1EEF0</span><span class="text">𞻰</span><span class="name">Arabic Mathematical Operator Meem with Hah with Tatweel</li>
+        <li><span class="unicode" role="math">&#x1EEF1</span><span class="text">𞻱</span><span class="name">Arabic Mathematical Operator Hah with Dal        
+	</ul>
+  </body>
+</html>


### PR DESCRIPTION
This is a list of 948 math symbols in UTF-8 in span with role math followed by the symbol in text and the name of the symbol. Each element is a a span with classes "unicode", "texte" and "name" so they are easy to trigger and modify with any automation. Referenced from [Compart](https://www.compart.com/en/unicode/category/Sm#UNC_SCRIPTS)

[Preview](https://rawcdn.githack.com/daisy/transitiontoepub/c6c9af66ecf23984f5267531105f4c26074f7ebb/symbols-list/math-role-UTF8-list.html)